### PR TITLE
chore(constitution): require auto-merge (squash)

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -99,7 +99,15 @@ If a CLI feature would require a new endpoint, a changed request/response shape,
 
 ### 6.1.4 Automation via `gh`
 
-- Cursor agents SHOULD use the GitHub CLI (`gh`) to create PRs, set titles/descriptions, and enable auto-merge once checks pass.
+- Cursor agents SHOULD use the GitHub CLI (`gh`) to create PRs and set titles/descriptions.
+- Cursor agents MUST enable auto-merge using **squash** for routine changes (so PRs merge automatically once required checks/reviews are satisfied).
+
+Example:
+
+```bash
+gh pr create --fill
+gh pr merge --auto --squash
+```
 
 ## 7. Versioning & distribution
 


### PR DESCRIPTION
Update the Automation via gh guidance to require enabling auto-merge using squash (for routine changes), with copy/pasteable commands.