### PR TITLE
Initialize Go module + root ebo command + global flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Notes:
 ## [Unreleased]
 
 ### Added
-- Documented hexagonal architecture boundaries and introduced an initial `internal/` package skeleton to guide CLI implementation layering.
+- Initialized the Go module and added a minimal `ebo` root command with global flags and environment variable equivalents.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,13 @@ ci: changelog-verify
 		fi; \
 		go vet ./...; \
 		go test ./...; \
+		covfile="$$(mktemp)"; \
+		go test ./internal/... -coverprofile="$$covfile" >/dev/null; \
+		total="$$(go tool cover -func="$$covfile" | awk '/^total:/{gsub(/%/,"",$$3); print $$3}')"; \
+		rm -f "$$covfile"; \
+		echo "Internal coverage: $$total%"; \
+		awk -v t="$$total" 'BEGIN{exit !(t+0 >= 85)}' \
+			|| { echo "ERROR: internal (non-generated) coverage must be >= 85%" >&2; exit 1; }; \
 		go build ./...; \
 	else \
 		echo "NOTE: No go.mod; skipping Go checks."; \

--- a/cmd/ebo/main.go
+++ b/cmd/ebo/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"os"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/adapters/in/cli"
+)
+
+func main() {
+	cmd := cli.NewRootCmd(cli.RootDeps{Env: nil, Stdout: os.Stdout, Stderr: os.Stderr})
+	if err := cmd.Execute(); err != nil {
+		// Exit code mapping is implemented in Issue #10; use 1 for now.
+		_, _ = os.Stderr.WriteString(err.Error() + "\n")
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/BennettSmith/ebo-planner-cli
+
+go 1.25.1
+
+require (
+	github.com/spf13/cobra v1.8.1
+	github.com/spf13/pflag v1.0.5
+)
+
+require github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/adapters/in/cli/root.go
+++ b/internal/adapters/in/cli/root.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
+	"github.com/spf13/cobra"
+)
+
+type RootDeps struct {
+	Env cliopts.EnvProvider
+
+	Stdout io.Writer
+	Stderr io.Writer
+
+	// OnResolved is a test hook invoked after flags/env are resolved.
+	OnResolved func(cliopts.Resolved)
+}
+
+func NewRootCmd(deps RootDeps) *cobra.Command {
+	if deps.Env == nil {
+		deps.Env = cliopts.OSEnv{}
+	}
+
+	defaults := cliopts.DefaultGlobalOptions()
+
+	cmd := &cobra.Command{
+		Use:           "ebo",
+		Short:         "ebo is a CLI for the Overland Trip Planning service",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := cliopts.ResolveGlobalOptions(cmd.Flags(), deps.Env, defaults)
+			if err != nil {
+				return err
+			}
+			if deps.OnResolved != nil {
+				deps.OnResolved(resolved)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Root currently has no subcommands (Issue #9 scope). Print help.
+			return cmd.Help()
+		},
+	}
+
+	cmd.SetOut(deps.Stdout)
+	cmd.SetErr(deps.Stderr)
+
+	cliopts.AddGlobalFlags(cmd.PersistentFlags(), defaults)
+
+	// Ensure PersistentPreRunE sees persistent flags as well.
+	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return fmt.Errorf("%w", err)
+	})
+
+	return cmd
+}

--- a/internal/adapters/in/cli/root_test.go
+++ b/internal/adapters/in/cli/root_test.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
+)
+
+func TestGlobalOptions_PreferenceFlagsOverEnv(t *testing.T) {
+	env := cliopts.MapEnv{
+		"EBO_API_URL":  "http://env",
+		"EBO_PROFILE":  "env-profile",
+		"EBO_OUTPUT":   "json",
+		"EBO_NO_COLOR": "1",
+		"EBO_TIMEOUT":  "10s",
+		"EBO_VERBOSE":  "1",
+	}
+
+	var got cliopts.Resolved
+	cmd := NewRootCmd(RootDeps{
+		Env:    env,
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		OnResolved: func(r cliopts.Resolved) {
+			got = r
+		},
+	})
+
+	cmd.SetArgs([]string{
+		"--api-url", "http://flag",
+		"--profile", "flag-profile",
+		"--output", "table",
+		"--no-color",
+		"--timeout", "2m",
+		"--verbose",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if got.Options.APIURL != "http://flag" {
+		t.Fatalf("APIURL: got %q", got.Options.APIURL)
+	}
+	if got.Options.Profile != "flag-profile" {
+		t.Fatalf("Profile: got %q", got.Options.Profile)
+	}
+	if got.Options.Output != cliopts.OutputTable {
+		t.Fatalf("Output: got %q", got.Options.Output)
+	}
+	if got.Options.NoColor != true {
+		t.Fatalf("NoColor: got %v", got.Options.NoColor)
+	}
+	if got.Options.Timeout.String() != "2m0s" {
+		t.Fatalf("Timeout: got %s", got.Options.Timeout)
+	}
+	if got.Options.Verbose != true {
+		t.Fatalf("Verbose: got %v", got.Options.Verbose)
+	}
+
+	for _, k := range []string{"api-url", "profile", "output", "no-color", "timeout", "verbose"} {
+		if got.Sources[k] != "flag" {
+			t.Fatalf("source(%s): got %q", k, got.Sources[k])
+		}
+	}
+}
+
+func TestGlobalOptions_EnvWhenFlagNotSet(t *testing.T) {
+	env := cliopts.MapEnv{
+		"EBO_PROFILE": "env-profile",
+		"EBO_OUTPUT":  "json",
+	}
+
+	var got cliopts.Resolved
+	cmd := NewRootCmd(RootDeps{
+		Env:    env,
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		OnResolved: func(r cliopts.Resolved) {
+			got = r
+		},
+	})
+
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if got.Options.Profile != "env-profile" {
+		t.Fatalf("Profile: got %q", got.Options.Profile)
+	}
+	if got.Options.Output != cliopts.OutputJSON {
+		t.Fatalf("Output: got %q", got.Options.Output)
+	}
+	if got.Sources["profile"] != "env" {
+		t.Fatalf("source(profile): got %q", got.Sources["profile"])
+	}
+	if got.Sources["output"] != "env" {
+		t.Fatalf("source(output): got %q", got.Sources["output"])
+	}
+}
+
+func TestGlobalOptions_DefaultsWhenUnset(t *testing.T) {
+	env := cliopts.MapEnv{}
+
+	var got cliopts.Resolved
+	cmd := NewRootCmd(RootDeps{
+		Env:    env,
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+		OnResolved: func(r cliopts.Resolved) {
+			got = r
+		},
+	})
+
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if got.Options.Profile != "default" {
+		t.Fatalf("Profile: got %q", got.Options.Profile)
+	}
+	if got.Options.Output != cliopts.OutputTable {
+		t.Fatalf("Output: got %q", got.Options.Output)
+	}
+	if got.Sources["profile"] != "default" {
+		t.Fatalf("source(profile): got %q", got.Sources["profile"])
+	}
+	if got.Sources["output"] != "default" {
+		t.Fatalf("source(output): got %q", got.Sources["output"])
+	}
+}
+
+func TestGlobalOptions_InvalidOutput(t *testing.T) {
+	env := cliopts.MapEnv{"EBO_OUTPUT": "nope"}
+
+	cmd := NewRootCmd(RootDeps{Env: env, Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/platform/cliopts/options.go
+++ b/internal/platform/cliopts/options.go
@@ -1,0 +1,184 @@
+package cliopts
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+type OutputFormat string
+
+const (
+	OutputTable OutputFormat = "table"
+	OutputJSON  OutputFormat = "json"
+)
+
+type GlobalOptions struct {
+	APIURL  string
+	Profile string
+	Output  OutputFormat
+	NoColor bool
+	Timeout time.Duration
+	Verbose bool
+}
+
+func DefaultGlobalOptions() GlobalOptions {
+	return GlobalOptions{
+		Profile: "default",
+		Output:  OutputTable,
+		Timeout: 30 * time.Second,
+	}
+}
+
+type EnvProvider interface {
+	LookupEnv(key string) (string, bool)
+}
+
+type OSEnv struct{}
+
+func (OSEnv) LookupEnv(key string) (string, bool) { return os.LookupEnv(key) }
+
+type MapEnv map[string]string
+
+func (m MapEnv) LookupEnv(key string) (string, bool) {
+	v, ok := m[key]
+	return v, ok
+}
+
+func AddGlobalFlags(fs *pflag.FlagSet, defaults GlobalOptions) {
+	fs.String("api-url", defaults.APIURL, "Override API base URL (or set EBO_API_URL)")
+	fs.String("profile", defaults.Profile, "Select profile (or set EBO_PROFILE)")
+	fs.String("output", string(defaults.Output), "Output format: table|json (or set EBO_OUTPUT)")
+	fs.Bool("no-color", defaults.NoColor, "Disable ANSI color (or set EBO_NO_COLOR=1)")
+	fs.Duration("timeout", defaults.Timeout, "Request timeout (e.g., 10s, 2m) (or set EBO_TIMEOUT)")
+	fs.Bool("verbose", defaults.Verbose, "Verbose logging to stderr (or set EBO_VERBOSE=1)")
+}
+
+type Resolved struct {
+	Options GlobalOptions
+	// Sources indicates where each setting was resolved from: "flag", "env", or "default".
+	Sources map[string]string
+}
+
+func ResolveGlobalOptions(fs *pflag.FlagSet, env EnvProvider, defaults GlobalOptions) (Resolved, error) {
+	out := Resolved{Options: defaults, Sources: map[string]string{}}
+
+	getString := func(flagName, envKey string, dst *string) error {
+		if f := fs.Lookup(flagName); f != nil && f.Changed {
+			v, err := fs.GetString(flagName)
+			if err != nil {
+				return err
+			}
+			*dst = v
+			out.Sources[flagName] = "flag"
+			return nil
+		}
+		if v, ok := env.LookupEnv(envKey); ok {
+			*dst = v
+			out.Sources[flagName] = "env"
+			return nil
+		}
+		out.Sources[flagName] = "default"
+		return nil
+	}
+
+	getBoolOne := func(flagName, envKey string, dst *bool) error {
+		if f := fs.Lookup(flagName); f != nil && f.Changed {
+			v, err := fs.GetBool(flagName)
+			if err != nil {
+				return err
+			}
+			*dst = v
+			out.Sources[flagName] = "flag"
+			return nil
+		}
+		if v, ok := env.LookupEnv(envKey); ok {
+			b, err := parseTruthy(v)
+			if err != nil {
+				return fmt.Errorf("%s: %w", envKey, err)
+			}
+			*dst = b
+			out.Sources[flagName] = "env"
+			return nil
+		}
+		out.Sources[flagName] = "default"
+		return nil
+	}
+
+	getDuration := func(flagName, envKey string, dst *time.Duration) error {
+		if f := fs.Lookup(flagName); f != nil && f.Changed {
+			v, err := fs.GetDuration(flagName)
+			if err != nil {
+				return err
+			}
+			*dst = v
+			out.Sources[flagName] = "flag"
+			return nil
+		}
+		if v, ok := env.LookupEnv(envKey); ok {
+			d, err := time.ParseDuration(v)
+			if err != nil {
+				return fmt.Errorf("%s: %w", envKey, err)
+			}
+			*dst = d
+			out.Sources[flagName] = "env"
+			return nil
+		}
+		out.Sources[flagName] = "default"
+		return nil
+	}
+
+	outputStr := string(defaults.Output)
+	if err := getString("api-url", "EBO_API_URL", &out.Options.APIURL); err != nil {
+		return Resolved{}, err
+	}
+	if err := getString("profile", "EBO_PROFILE", &out.Options.Profile); err != nil {
+		return Resolved{}, err
+	}
+	if err := getString("output", "EBO_OUTPUT", &outputStr); err != nil {
+		return Resolved{}, err
+	}
+	if err := getBoolOne("no-color", "EBO_NO_COLOR", &out.Options.NoColor); err != nil {
+		return Resolved{}, err
+	}
+	if err := getDuration("timeout", "EBO_TIMEOUT", &out.Options.Timeout); err != nil {
+		return Resolved{}, err
+	}
+	if err := getBoolOne("verbose", "EBO_VERBOSE", &out.Options.Verbose); err != nil {
+		return Resolved{}, err
+	}
+
+	out.Options.Output = OutputFormat(strings.ToLower(strings.TrimSpace(outputStr)))
+	switch out.Options.Output {
+	case OutputTable, OutputJSON:
+		// ok
+	default:
+		return Resolved{}, fmt.Errorf("invalid --output %q (expected table|json)", outputStr)
+	}
+
+	if out.Options.Profile == "" {
+		return Resolved{}, fmt.Errorf("invalid --profile: must be non-empty")
+	}
+
+	if out.Options.Timeout < 0 {
+		return Resolved{}, fmt.Errorf("invalid --timeout: must be non-negative")
+	}
+
+	return out, nil
+}
+
+func parseTruthy(v string) (bool, error) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false, nil
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, fmt.Errorf("invalid boolean value %q", v)
+	}
+	return b, nil
+}

--- a/internal/platform/cliopts/options_test.go
+++ b/internal/platform/cliopts/options_test.go
@@ -1,0 +1,171 @@
+package cliopts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+func TestResolveGlobalOptions_Defaults(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	defaults := DefaultGlobalOptions()
+	AddGlobalFlags(fs, defaults)
+	if err := fs.Parse([]string{}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	r, err := ResolveGlobalOptions(fs, MapEnv{}, defaults)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	if r.Options.Profile != "default" {
+		t.Fatalf("profile: got %q", r.Options.Profile)
+	}
+	if r.Options.Output != OutputTable {
+		t.Fatalf("output: got %q", r.Options.Output)
+	}
+	if r.Options.Timeout != 30*time.Second {
+		t.Fatalf("timeout: got %s", r.Options.Timeout)
+	}
+}
+
+func TestResolveGlobalOptions_EnvTakesEffect(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	defaults := DefaultGlobalOptions()
+	AddGlobalFlags(fs, defaults)
+	if err := fs.Parse([]string{}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	env := MapEnv{
+		"EBO_OUTPUT":   "json",
+		"EBO_TIMEOUT":  "2m",
+		"EBO_VERBOSE":  "true",
+		"EBO_NO_COLOR": "1",
+	}
+
+	r, err := ResolveGlobalOptions(fs, env, defaults)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	if r.Options.Output != OutputJSON {
+		t.Fatalf("output: got %q", r.Options.Output)
+	}
+	if r.Options.Timeout != 2*time.Minute {
+		t.Fatalf("timeout: got %s", r.Options.Timeout)
+	}
+	if !r.Options.Verbose {
+		t.Fatalf("verbose: got %v", r.Options.Verbose)
+	}
+	if !r.Options.NoColor {
+		t.Fatalf("noColor: got %v", r.Options.NoColor)
+	}
+}
+
+func TestParseTruthy(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"  ", false},
+		{"1", true},
+		{"true", true},
+		{"FALSE", false},
+	} {
+		got, err := parseTruthy(tc.in)
+		if err != nil {
+			t.Fatalf("parseTruthy(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("parseTruthy(%q): got %v want %v", tc.in, got, tc.want)
+		}
+	}
+
+	if _, err := parseTruthy("nope"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestResolveGlobalOptions_FlagsOverrideEnv(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	defaults := DefaultGlobalOptions()
+	AddGlobalFlags(fs, defaults)
+	if err := fs.Parse([]string{"--output", "table", "--timeout", "1s", "--verbose"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	env := MapEnv{
+		"EBO_OUTPUT":  "json",
+		"EBO_TIMEOUT": "2m",
+		"EBO_VERBOSE": "0",
+	}
+
+	r, err := ResolveGlobalOptions(fs, env, defaults)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	if r.Options.Output != OutputTable {
+		t.Fatalf("output: got %q", r.Options.Output)
+	}
+	if r.Options.Timeout != 1*time.Second {
+		t.Fatalf("timeout: got %s", r.Options.Timeout)
+	}
+	if !r.Options.Verbose {
+		t.Fatalf("verbose: got %v", r.Options.Verbose)
+	}
+	if r.Sources["output"] != "flag" || r.Sources["timeout"] != "flag" || r.Sources["verbose"] != "flag" {
+		t.Fatalf("sources: got %#v", r.Sources)
+	}
+}
+
+func TestResolveGlobalOptions_InvalidEnvValues(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	defaults := DefaultGlobalOptions()
+	AddGlobalFlags(fs, defaults)
+	if err := fs.Parse([]string{}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	for name, env := range map[string]MapEnv{
+		"bad output":   {"EBO_OUTPUT": "nope"},
+		"bad duration": {"EBO_TIMEOUT": "nope"},
+		"bad bool":     {"EBO_VERBOSE": "nope"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ResolveGlobalOptions(fs, env, defaults); err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}
+
+func TestResolveGlobalOptions_Validation(t *testing.T) {
+	defaults := DefaultGlobalOptions()
+
+	t.Run("empty profile", func(t *testing.T) {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		AddGlobalFlags(fs, defaults)
+		if err := fs.Parse([]string{"--profile", ""}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if _, err := ResolveGlobalOptions(fs, MapEnv{}, defaults); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("negative timeout", func(t *testing.T) {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		AddGlobalFlags(fs, defaults)
+		if err := fs.Parse([]string{"--timeout", "-1s"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if _, err := ResolveGlobalOptions(fs, MapEnv{}, defaults); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}


### PR DESCRIPTION
Closes #9\n\n- Initializes Go module and adds a minimal Cobra-based  root command.\n- Implements required global flags + env var equivalents with precedence (flags > env > defaults) and unit tests.\n- Updates CI to enforce >=85% internal (non-generated) coverage.