### PR TITLE
Implement JSON envelope + stderr/stdout rules + exit code mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notes:
 ## [Unreleased]
 
 ### Added
+- Added a stable JSON output envelope and standardized exit-code mapping for errors.
 - Initialized the Go module and added a minimal `ebo` root command with global flags and environment variable equivalents.
 
 ### Changed

--- a/cmd/ebo/main.go
+++ b/cmd/ebo/main.go
@@ -1,16 +1,63 @@
 package main
 
 import (
+	"errors"
 	"os"
+	"strings"
 
 	"github.com/BennettSmith/ebo-planner-cli/internal/adapters/in/cli"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/envelope"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
 )
 
 func main() {
-	cmd := cli.NewRootCmd(cli.RootDeps{Env: nil, Stdout: os.Stdout, Stderr: os.Stderr})
+	env := cliopts.OSEnv{}
+	defaults := cliopts.DefaultGlobalOptions()
+	peek := cliopts.PeekGlobalOptions(os.Args[1:], env, defaults)
+
+	cmd := cli.NewRootCmd(cli.RootDeps{Env: env, Stdout: os.Stdout, Stderr: os.Stderr})
 	if err := cmd.Execute(); err != nil {
-		// Exit code mapping is implemented in Issue #10; use 1 for now.
-		_, _ = os.Stderr.WriteString(err.Error() + "\n")
-		os.Exit(1)
+		// Best-effort classify errors into the required exit code contract.
+		mapped := err
+		// Cobra/pflag parsing errors don't expose a stable exported type; use a best-effort heuristic.
+		if looksLikeUsageError(err) {
+			mapped = exitcode.New(exitcode.KindUsage, "usage error", err)
+		}
+
+		code := exitcode.Code(mapped)
+
+		if peek.Output == cliopts.OutputJSON {
+			_ = envelope.WriteJSON(os.Stdout, envelope.Envelope{
+				Meta: envelope.Meta{APIURL: peek.APIURL, Profile: peek.Profile},
+				Error: &envelope.ErrorBody{
+					Code:    stringExitCodeKind(mapped),
+					Message: mapped.Error(),
+				},
+			})
+		} else {
+			_, _ = os.Stderr.WriteString(mapped.Error() + "\n")
+		}
+
+		os.Exit(code)
 	}
+}
+
+func stringExitCodeKind(err error) string {
+	var e *exitcode.Error
+	if errors.As(err, &e) {
+		return string(e.Kind)
+	}
+	return string(exitcode.KindUnexpected)
+}
+
+func looksLikeUsageError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "unknown flag") ||
+		strings.Contains(msg, "flag needs an argument") ||
+		strings.Contains(msg, "requires an argument") ||
+		strings.Contains(msg, "invalid argument")
 }

--- a/internal/platform/cliopts/peek.go
+++ b/internal/platform/cliopts/peek.go
@@ -1,0 +1,108 @@
+package cliopts
+
+import (
+	"strings"
+	"time"
+)
+
+// PeekGlobalOptions best-effort resolves global options from args/env/defaults.
+//
+// This is intentionally simpler than ResolveGlobalOptions: it exists so the
+// entrypoint can decide whether to emit JSON output even when Cobra flag parsing
+// fails (e.g., unknown flag).
+func PeekGlobalOptions(args []string, env EnvProvider, defaults GlobalOptions) GlobalOptions {
+	opts := defaults
+	outputSet := false
+	profileSet := false
+	apiURLSet := false
+	noColorSet := false
+	timeoutSet := false
+	verboseSet := false
+
+	// flags first
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--api-url" && i+1 < len(args):
+			opts.APIURL = args[i+1]
+			apiURLSet = true
+			i++
+		case strings.HasPrefix(a, "--api-url="):
+			opts.APIURL = strings.TrimPrefix(a, "--api-url=")
+			apiURLSet = true
+		case a == "--profile" && i+1 < len(args):
+			opts.Profile = args[i+1]
+			profileSet = true
+			i++
+		case strings.HasPrefix(a, "--profile="):
+			opts.Profile = strings.TrimPrefix(a, "--profile=")
+			profileSet = true
+		case a == "--output" && i+1 < len(args):
+			opts.Output = OutputFormat(strings.ToLower(args[i+1]))
+			outputSet = true
+			i++
+		case strings.HasPrefix(a, "--output="):
+			opts.Output = OutputFormat(strings.ToLower(strings.TrimPrefix(a, "--output=")))
+			outputSet = true
+		case a == "--no-color":
+			opts.NoColor = true
+			noColorSet = true
+		case a == "--timeout" && i+1 < len(args):
+			if d, err := time.ParseDuration(args[i+1]); err == nil {
+				opts.Timeout = d
+				timeoutSet = true
+			}
+			i++
+		case strings.HasPrefix(a, "--timeout="):
+			if d, err := time.ParseDuration(strings.TrimPrefix(a, "--timeout=")); err == nil {
+				opts.Timeout = d
+				timeoutSet = true
+			}
+		case a == "--verbose":
+			opts.Verbose = true
+			verboseSet = true
+		}
+	}
+
+	// then env
+	if env != nil {
+		if !apiURLSet {
+			if v, ok := env.LookupEnv("EBO_API_URL"); ok {
+				opts.APIURL = v
+			}
+		}
+		if !profileSet {
+			if v, ok := env.LookupEnv("EBO_PROFILE"); ok {
+				opts.Profile = v
+			}
+		}
+		if !outputSet {
+			if v, ok := env.LookupEnv("EBO_OUTPUT"); ok {
+				opts.Output = OutputFormat(strings.ToLower(v))
+			}
+		}
+		if !noColorSet {
+			if v, ok := env.LookupEnv("EBO_NO_COLOR"); ok {
+				if b, err := parseTruthy(v); err == nil {
+					opts.NoColor = b
+				}
+			}
+		}
+		if !timeoutSet {
+			if v, ok := env.LookupEnv("EBO_TIMEOUT"); ok {
+				if d, err := time.ParseDuration(v); err == nil {
+					opts.Timeout = d
+				}
+			}
+		}
+		if !verboseSet {
+			if v, ok := env.LookupEnv("EBO_VERBOSE"); ok {
+				if b, err := parseTruthy(v); err == nil {
+					opts.Verbose = b
+				}
+			}
+		}
+	}
+
+	return opts
+}

--- a/internal/platform/cliopts/peek_test.go
+++ b/internal/platform/cliopts/peek_test.go
@@ -1,0 +1,77 @@
+package cliopts
+
+import "testing"
+
+func TestPeekGlobalOptions_FlagOverridesEnv(t *testing.T) {
+	defaults := DefaultGlobalOptions()
+	env := MapEnv{"EBO_OUTPUT": "json", "EBO_PROFILE": "env"}
+
+	opts := PeekGlobalOptions([]string{"--output", "table", "--profile", "flag"}, env, defaults)
+	if opts.Output != OutputTable {
+		t.Fatalf("output: got %q", opts.Output)
+	}
+	if opts.Profile != "flag" {
+		t.Fatalf("profile: got %q", opts.Profile)
+	}
+}
+
+func TestPeekGlobalOptions_FlagEqualsForm(t *testing.T) {
+	defaults := DefaultGlobalOptions()
+	opts := PeekGlobalOptions([]string{"--output=json", "--profile=p"}, MapEnv{}, defaults)
+	if opts.Output != OutputJSON {
+		t.Fatalf("output: got %q", opts.Output)
+	}
+	if opts.Profile != "p" {
+		t.Fatalf("profile: got %q", opts.Profile)
+	}
+}
+
+func TestPeekGlobalOptions_EnvWhenNoFlags(t *testing.T) {
+	defaults := DefaultGlobalOptions()
+	env := MapEnv{"EBO_OUTPUT": "json", "EBO_NO_COLOR": "1", "EBO_VERBOSE": "true"}
+
+	opts := PeekGlobalOptions([]string{}, env, defaults)
+	if opts.Output != OutputJSON {
+		t.Fatalf("output: got %q", opts.Output)
+	}
+	if !opts.NoColor {
+		t.Fatalf("noColor: got %v", opts.NoColor)
+	}
+	if !opts.Verbose {
+		t.Fatalf("verbose: got %v", opts.Verbose)
+	}
+}
+
+func TestPeekGlobalOptions_EnvInvalidDoesNotCrash(t *testing.T) {
+	defaults := DefaultGlobalOptions()
+	env := MapEnv{"EBO_TIMEOUT": "nope", "EBO_NO_COLOR": "nope"}
+
+	opts := PeekGlobalOptions([]string{}, env, defaults)
+	// stays at defaults
+	if opts.Timeout != defaults.Timeout {
+		t.Fatalf("timeout: got %s", opts.Timeout)
+	}
+	if opts.NoColor != defaults.NoColor {
+		t.Fatalf("noColor: got %v", opts.NoColor)
+	}
+}
+
+func TestPeekGlobalOptions_TimeoutFlagAndEqualsForm(t *testing.T) {
+	defaults := DefaultGlobalOptions()
+
+	opts := PeekGlobalOptions([]string{"--timeout", "2m", "--timeout=1s"}, MapEnv{}, defaults)
+	// last one wins in our simple scan
+	if opts.Timeout.String() != "1s" {
+		t.Fatalf("timeout: got %s", opts.Timeout)
+	}
+}
+
+func TestPeekGlobalOptions_VerboseEnvFalse(t *testing.T) {
+	defaults := DefaultGlobalOptions()
+	env := MapEnv{"EBO_VERBOSE": "false"}
+
+	opts := PeekGlobalOptions([]string{}, env, defaults)
+	if opts.Verbose {
+		t.Fatalf("verbose: got %v", opts.Verbose)
+	}
+}

--- a/internal/platform/envelope/envelope.go
+++ b/internal/platform/envelope/envelope.go
@@ -1,0 +1,30 @@
+package envelope
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Meta struct {
+	APIURL         string `json:"apiUrl"`
+	Profile        string `json:"profile"`
+	IdempotencyKey string `json:"idempotencyKey,omitempty"`
+	RequestID      string `json:"requestId,omitempty"`
+}
+
+type ErrorBody struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message"`
+}
+
+type Envelope struct {
+	Data  any        `json:"data,omitempty"`
+	Meta  Meta       `json:"meta"`
+	Error *ErrorBody `json:"error,omitempty"`
+}
+
+func WriteJSON(w io.Writer, env Envelope) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(env)
+}

--- a/internal/platform/envelope/envelope_test.go
+++ b/internal/platform/envelope/envelope_test.go
@@ -1,0 +1,54 @@
+package envelope
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestWriteJSON_SuccessEnvelope(t *testing.T) {
+	buf := &bytes.Buffer{}
+	env := Envelope{
+		Data: map[string]any{"ok": true},
+		Meta: Meta{APIURL: "http://x", Profile: "default"},
+	}
+	if err := WriteJSON(buf, env); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["meta"] == nil {
+		t.Fatalf("expected meta")
+	}
+	if got["data"] == nil {
+		t.Fatalf("expected data")
+	}
+	if _, ok := got["error"]; ok {
+		t.Fatalf("did not expect error")
+	}
+}
+
+func TestWriteJSON_ErrorEnvelope(t *testing.T) {
+	buf := &bytes.Buffer{}
+	env := Envelope{
+		Meta:  Meta{Profile: "p"},
+		Error: &ErrorBody{Code: "SOME_ERROR", Message: "nope"},
+	}
+	if err := WriteJSON(buf, env); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var got struct {
+		Meta  Meta      `json:"meta"`
+		Error ErrorBody `json:"error"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Error.Message != "nope" {
+		t.Fatalf("message: got %q", got.Error.Message)
+	}
+}

--- a/internal/platform/exitcode/exitcode.go
+++ b/internal/platform/exitcode/exitcode.go
@@ -1,0 +1,81 @@
+package exitcode
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Codes are the minimum required exit-code contract from docs/cli-spec.md.
+const (
+	Success    = 0
+	Unexpected = 1
+	Usage      = 2
+	Auth       = 3
+	NotFound   = 4
+	Conflict   = 5
+	Validation = 6
+	Server     = 7
+)
+
+type Kind string
+
+const (
+	KindUnexpected Kind = "unexpected"
+	KindUsage      Kind = "usage"
+	KindAuth       Kind = "auth"
+	KindNotFound   Kind = "not_found"
+	KindConflict   Kind = "conflict"
+	KindValidation Kind = "validation"
+	KindServer     Kind = "server"
+)
+
+type Error struct {
+	Kind Kind
+	Msg  string
+	Err  error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Err != nil && e.Msg != "" {
+		return fmt.Sprintf("%s: %v", e.Msg, e.Err)
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return e.Msg
+}
+
+func (e *Error) Unwrap() error { return e.Err }
+
+func New(kind Kind, msg string, err error) *Error {
+	return &Error{Kind: kind, Msg: msg, Err: err}
+}
+
+func Code(err error) int {
+	if err == nil {
+		return Success
+	}
+	var e *Error
+	if errors.As(err, &e) {
+		switch e.Kind {
+		case KindUsage:
+			return Usage
+		case KindAuth:
+			return Auth
+		case KindNotFound:
+			return NotFound
+		case KindConflict:
+			return Conflict
+		case KindValidation:
+			return Validation
+		case KindServer:
+			return Server
+		default:
+			return Unexpected
+		}
+	}
+	return Unexpected
+}

--- a/internal/platform/exitcode/exitcode_test.go
+++ b/internal/platform/exitcode/exitcode_test.go
@@ -1,0 +1,54 @@
+package exitcode
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCode(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil", nil, Success},
+		{"usage", New(KindUsage, "bad args", nil), Usage},
+		{"auth", New(KindAuth, "no token", nil), Auth},
+		{"notfound", New(KindNotFound, "missing", nil), NotFound},
+		{"conflict", New(KindConflict, "dup", nil), Conflict},
+		{"validation", New(KindValidation, "invalid", nil), Validation},
+		{"server", New(KindServer, "down", nil), Server},
+		{"unexpected", New(KindUnexpected, "boom", nil), Unexpected},
+		{"plain error", errors.New("x"), Unexpected},
+		{"unknown kind", New("weird", "x", nil), Unexpected},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Code(tc.err); got != tc.want {
+				t.Fatalf("got %d want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestErrorFormattingAndUnwrap(t *testing.T) {
+	inner := errors.New("inner")
+
+	e := New(KindUsage, "bad", inner)
+	if e.Error() != "bad: inner" {
+		t.Fatalf("error: got %q", e.Error())
+	}
+	if !errors.Is(e, inner) {
+		t.Fatalf("expected unwrap")
+	}
+
+	e2 := New(KindUsage, "", inner)
+	if e2.Error() != "inner" {
+		t.Fatalf("error: got %q", e2.Error())
+	}
+
+	e3 := New(KindUsage, "msg", nil)
+	if e3.Error() != "msg" {
+		t.Fatalf("error: got %q", e3.Error())
+	}
+}


### PR DESCRIPTION
Closes #10\n\n- Adds stable JSON envelope writer and exit-code mapping utilities.\n- Wires entrypoint to emit JSON errors to stdout when --output json (and human errors to stderr otherwise).\n- Adds unit tests and keeps internal coverage >=85%.