### PR TITLE
Config store + profiles + precedence (preserve unknown YAML)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notes:
 ## [Unreleased]
 
 ### Added
+- Added YAML-backed config storage with profile support and precedence resolution (preserves unknown fields on rewrite).
 - Added a stable JSON output envelope and standardized exit-code mapping for errors.
 - Initialized the Go module and added a minimal `ebo` root command with global flags and environment variable equivalents.
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.1
 require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/adapters/out/configfile/store.go
+++ b/internal/adapters/out/configfile/store.go
@@ -1,0 +1,107 @@
+package configfile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"gopkg.in/yaml.v3"
+)
+
+type Env interface {
+	LookupEnv(key string) (string, bool)
+}
+
+type OSEnv struct{}
+
+func (OSEnv) LookupEnv(key string) (string, bool) { return os.LookupEnv(key) }
+
+type Store struct {
+	Env Env
+}
+
+func (s Store) Path(ctx context.Context) (string, error) {
+	_ = ctx
+	base, err := s.configDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "ebo", "config.yaml"), nil
+}
+
+func (s Store) Load(ctx context.Context) (config.Document, error) {
+	path, err := s.Path(ctx)
+	if err != nil {
+		return config.Document{}, err
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return config.NewEmptyDocument(), nil
+		}
+		return config.Document{}, err
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		return config.Document{}, err
+	}
+	// Ensure document shape.
+	if doc.Kind == 0 {
+		return config.NewEmptyDocument(), nil
+	}
+	return config.Document{Root: &doc}, nil
+}
+
+func (s Store) Save(ctx context.Context, doc config.Document) error {
+	path, err := s.Path(ctx)
+	if err != nil {
+		return err
+	}
+	if doc.Root == nil {
+		return fmt.Errorf("nil document")
+	}
+
+	// Ensure parent dir exists.
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	b, err := yaml.Marshal(doc.Root)
+	if err != nil {
+		return err
+	}
+
+	// Write atomically with restrictive permissions.
+	tmp, err := os.CreateTemp(filepath.Dir(path), "config-*.yaml")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func (s Store) configDir() (string, error) {
+	if s.Env == nil {
+		s.Env = OSEnv{}
+	}
+	if v, ok := s.Env.LookupEnv("EBO_CONFIG_DIR"); ok && v != "" {
+		return v, nil
+	}
+	return os.UserConfigDir()
+}

--- a/internal/adapters/out/configfile/store_test.go
+++ b/internal/adapters/out/configfile/store_test.go
@@ -1,0 +1,130 @@
+package configfile
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"gopkg.in/yaml.v3"
+)
+
+type mapEnv map[string]string
+
+func (m mapEnv) LookupEnv(key string) (string, bool) {
+	v, ok := m[key]
+	return v, ok
+}
+
+func TestPath_UsesEBOConfigDirOverride(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+
+	s := Store{Env: mapEnv{"EBO_CONFIG_DIR": tmp}}
+	p, err := s.Path(ctx)
+	if err != nil {
+		t.Fatalf("path: %v", err)
+	}
+	want := filepath.Join(tmp, "ebo", "config.yaml")
+	if p != want {
+		t.Fatalf("got %q want %q", p, want)
+	}
+}
+
+func TestSaveLoad_PreservesUnknownFields(t *testing.T) {
+	ctx := context.Background()
+	base := t.TempDir()
+
+	s := Store{Env: mapEnv{"EBO_CONFIG_DIR": base}}
+	p, err := s.Path(ctx)
+	if err != nil {
+		t.Fatalf("path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	original := strings.TrimSpace(`currentProfile: staging
+x-top: 123
+profiles:
+  staging:
+    apiUrl: https://old.example
+    x-unknown: keepme
+`) + "\n"
+	if err := os.WriteFile(p, []byte(original), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	doc, err := s.Load(ctx)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	doc, err = config.WithCurrentProfile(doc, "staging")
+	if err != nil {
+		t.Fatalf("with current: %v", err)
+	}
+	doc, err = config.WithProfileAPIURL(doc, "staging", "https://new.example")
+	if err != nil {
+		t.Fatalf("with apiUrl: %v", err)
+	}
+
+	if err := s.Save(ctx, doc); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	reloaded, err := s.Load(ctx)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	b, err := yaml.Marshal(reloaded.Root)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := string(b)
+	if !strings.Contains(out, "x-top: 123") {
+		t.Fatalf("expected top-level unknown field preserved, got:\n%s", out)
+	}
+	if !strings.Contains(out, "x-unknown: keepme") {
+		t.Fatalf("expected profile unknown field preserved, got:\n%s", out)
+	}
+	if !strings.Contains(out, "apiUrl: https://new.example") {
+		t.Fatalf("expected apiUrl updated, got:\n%s", out)
+	}
+
+	st, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if st.Mode().Perm() != 0o600 {
+		t.Fatalf("expected 0600 perms, got %o", st.Mode().Perm())
+	}
+}
+
+func TestLoad_MissingFileReturnsEmptyDoc(t *testing.T) {
+	ctx := context.Background()
+	base := t.TempDir()
+	s := Store{Env: mapEnv{"EBO_CONFIG_DIR": base}}
+	doc, err := s.Load(ctx)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	v, err := config.ViewOf(doc)
+	if err != nil {
+		t.Fatalf("view: %v", err)
+	}
+	if v.CurrentProfile != "" {
+		t.Fatalf("currentProfile: got %q", v.CurrentProfile)
+	}
+}
+
+func TestSave_NilDocumentErrors(t *testing.T) {
+	ctx := context.Background()
+	base := t.TempDir()
+	s := Store{Env: mapEnv{"EBO_CONFIG_DIR": base}}
+	if err := s.Save(ctx, config.Document{}); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/platform/config/accessors.go
+++ b/internal/platform/config/accessors.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+func ViewOf(doc Document) (View, error) {
+	root, err := rootMapping(doc)
+	if err != nil {
+		return View{}, err
+	}
+
+	v := View{Profiles: map[string]ProfileView{}}
+	if cp := mapGet(root, "currentProfile"); cp != nil && cp.Kind == yaml.ScalarNode {
+		v.CurrentProfile = cp.Value
+	}
+
+	profiles := mapGet(root, "profiles")
+	if profiles != nil && profiles.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(profiles.Content); i += 2 {
+			k := profiles.Content[i]
+			pv := profiles.Content[i+1]
+			if k.Kind != yaml.ScalarNode || pv.Kind != yaml.MappingNode {
+				continue
+			}
+			p := ProfileView{}
+			if au := mapGet(pv, "apiUrl"); au != nil && au.Kind == yaml.ScalarNode {
+				p.APIURL = au.Value
+			}
+			v.Profiles[k.Value] = p
+		}
+	}
+
+	return v, nil
+}
+
+func WithCurrentProfile(doc Document, profile string) (Document, error) {
+	root, err := rootMapping(doc)
+	if err != nil {
+		return Document{}, err
+	}
+	mapSetScalar(root, "currentProfile", profile)
+	return doc, nil
+}
+
+func WithProfileAPIURL(doc Document, profile, apiURL string) (Document, error) {
+	root, err := rootMapping(doc)
+	if err != nil {
+		return Document{}, err
+	}
+	profiles := mapEnsureMapping(root, "profiles")
+	pnode := mapEnsureMapping(profiles, profile)
+	mapSetScalar(pnode, "apiUrl", apiURL)
+	return doc, nil
+}

--- a/internal/platform/config/accessors_test.go
+++ b/internal/platform/config/accessors_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestViewOf_IgnoresNonScalarAndNonMappingShapes(t *testing.T) {
+	// Build a doc with odd shapes: currentProfile as mapping, profiles as scalar.
+	doc := NewEmptyDocument()
+	root := doc.Root.Content[0]
+	mapSetNode(root, "currentProfile", &yaml.Node{Kind: yaml.MappingNode})
+	mapSetNode(root, "profiles", &yaml.Node{Kind: yaml.ScalarNode, Value: "nope"})
+
+	v, err := ViewOf(doc)
+	if err != nil {
+		t.Fatalf("view: %v", err)
+	}
+	if v.CurrentProfile != "" {
+		t.Fatalf("currentProfile: got %q", v.CurrentProfile)
+	}
+	if len(v.Profiles) != 0 {
+		t.Fatalf("profiles: expected empty")
+	}
+}

--- a/internal/platform/config/doc.go
+++ b/internal/platform/config/doc.go
@@ -1,0 +1,26 @@
+package config
+
+import "gopkg.in/yaml.v3"
+
+// Document is a YAML-backed configuration document that preserves unknown fields.
+//
+// The canonical on-disk format is YAML.
+//
+// This type is used as the value passed through the ConfigStore port.
+// Keeping the raw yaml.Node allows round-tripping unknown keys.
+//
+// This is intentionally minimal and will grow as issues #15/#16 add CLI commands.
+//
+// See docs/cli-spec.md "Config and profiles".
+type Document struct {
+	Root *yaml.Node
+}
+
+type View struct {
+	CurrentProfile string
+	Profiles       map[string]ProfileView
+}
+
+type ProfileView struct {
+	APIURL string
+}

--- a/internal/platform/config/resolve.go
+++ b/internal/platform/config/resolve.go
@@ -1,0 +1,32 @@
+package config
+
+import "github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
+
+type Effective struct {
+	Profile string
+	APIURL  string
+}
+
+// ResolveEffective combines CLI options (including their source) with config-file
+// settings.
+//
+// Precedence (highest -> lowest):
+//  1. CLI flags
+//  2. env vars
+//  3. config file (currentProfile + profiles.<name>.apiUrl)
+//  4. defaults
+func ResolveEffective(cli cliopts.Resolved, cfg View) Effective {
+	profile := cli.Options.Profile
+	if cli.Sources["profile"] == "default" && cfg.CurrentProfile != "" {
+		profile = cfg.CurrentProfile
+	}
+
+	apiURL := cli.Options.APIURL
+	if cli.Sources["api-url"] == "default" {
+		if p, ok := cfg.Profiles[profile]; ok && p.APIURL != "" {
+			apiURL = p.APIURL
+		}
+	}
+
+	return Effective{Profile: profile, APIURL: apiURL}
+}

--- a/internal/platform/config/resolve_test.go
+++ b/internal/platform/config/resolve_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
+	"github.com/spf13/pflag"
+)
+
+func resolvedFromArgs(t *testing.T, args []string) cliopts.Resolved {
+	t.Helper()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	defaults := cliopts.DefaultGlobalOptions()
+	cliopts.AddGlobalFlags(fs, defaults)
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	r, err := cliopts.ResolveGlobalOptions(fs, cliopts.MapEnv{}, defaults)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	return r
+}
+
+func TestResolveEffective_UsesConfigCurrentProfileWhenProfileNotSpecified(t *testing.T) {
+	cli := resolvedFromArgs(t, []string{})
+
+	cfg := View{
+		CurrentProfile: "staging",
+		Profiles: map[string]ProfileView{
+			"staging": {APIURL: "https://staging"},
+		},
+	}
+
+	e := ResolveEffective(cli, cfg)
+	if e.Profile != "staging" {
+		t.Fatalf("profile: got %q", e.Profile)
+	}
+	if e.APIURL != "https://staging" {
+		t.Fatalf("apiUrl: got %q", e.APIURL)
+	}
+}
+
+func TestResolveEffective_ProfileFlagOverridesConfig(t *testing.T) {
+	cli := resolvedFromArgs(t, []string{"--profile", "dev"})
+	cfg := View{CurrentProfile: "staging", Profiles: map[string]ProfileView{"staging": {APIURL: "https://staging"}, "dev": {APIURL: "https://dev"}}}
+
+	e := ResolveEffective(cli, cfg)
+	if e.Profile != "dev" {
+		t.Fatalf("profile: got %q", e.Profile)
+	}
+	if e.APIURL != "https://dev" {
+		t.Fatalf("apiUrl: got %q", e.APIURL)
+	}
+}
+
+func TestResolveEffective_APIURLFlagOverridesProfileAPIURL(t *testing.T) {
+	cli := resolvedFromArgs(t, []string{"--api-url", "http://override"})
+	cfg := View{CurrentProfile: "staging", Profiles: map[string]ProfileView{"staging": {APIURL: "https://staging"}}}
+
+	e := ResolveEffective(cli, cfg)
+	if e.APIURL != "http://override" {
+		t.Fatalf("apiUrl: got %q", e.APIURL)
+	}
+}
+
+func TestResolveEffective_ProfileDefaultIfNoConfigCurrentProfile(t *testing.T) {
+	cli := resolvedFromArgs(t, []string{})
+	cfg := View{CurrentProfile: "", Profiles: map[string]ProfileView{"default": {APIURL: "https://d"}}}
+
+	e := ResolveEffective(cli, cfg)
+	if e.Profile != "default" {
+		t.Fatalf("profile: got %q", e.Profile)
+	}
+	if e.APIURL != "https://d" {
+		t.Fatalf("apiUrl: got %q", e.APIURL)
+	}
+}
+
+func TestResolveEffective_IgnoresOtherClioptsFields(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	defaults := cliopts.DefaultGlobalOptions()
+	cliopts.AddGlobalFlags(fs, defaults)
+	_ = fs.Parse([]string{"--timeout", "1s"})
+	r, err := cliopts.ResolveGlobalOptions(fs, cliopts.MapEnv{}, defaults)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if r.Options.Timeout != 1*time.Second {
+		t.Fatalf("timeout: got %s", r.Options.Timeout)
+	}
+	_ = ResolveEffective(r, View{})
+}

--- a/internal/platform/config/yamlnode.go
+++ b/internal/platform/config/yamlnode.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func NewEmptyDocument() Document {
+	doc := &yaml.Node{Kind: yaml.DocumentNode}
+	root := &yaml.Node{Kind: yaml.MappingNode}
+	doc.Content = []*yaml.Node{root}
+	return Document{Root: doc}
+}
+
+func rootMapping(doc Document) (*yaml.Node, error) {
+	if doc.Root == nil || doc.Root.Kind != yaml.DocumentNode || len(doc.Root.Content) == 0 {
+		return nil, fmt.Errorf("invalid yaml document")
+	}
+	root := doc.Root.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("invalid yaml root: expected mapping")
+	}
+	return root, nil
+}
+
+func mapGet(m *yaml.Node, key string) *yaml.Node {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		k := m.Content[i]
+		v := m.Content[i+1]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			return v
+		}
+	}
+	return nil
+}
+
+func mapSetScalar(m *yaml.Node, key, value string) {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		k := m.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			m.Content[i+1] = &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+			return
+		}
+	}
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value},
+	)
+}
+
+func mapEnsureMapping(m *yaml.Node, key string) *yaml.Node {
+	if v := mapGet(m, key); v != nil {
+		if v.Kind == yaml.MappingNode {
+			return v
+		}
+		// Overwrite non-mapping with mapping (known key path).
+		newMap := &yaml.Node{Kind: yaml.MappingNode}
+		mapSetNode(m, key, newMap)
+		return newMap
+	}
+	newMap := &yaml.Node{Kind: yaml.MappingNode}
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		newMap,
+	)
+	return newMap
+}
+
+func mapSetNode(m *yaml.Node, key string, node *yaml.Node) {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		k := m.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			m.Content[i+1] = node
+			return
+		}
+	}
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		node,
+	)
+}

--- a/internal/platform/config/yamlnode_internal_test.go
+++ b/internal/platform/config/yamlnode_internal_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestMapSetScalar_UpdatesExistingKey(t *testing.T) {
+	m := &yaml.Node{Kind: yaml.MappingNode}
+	mapSetScalar(m, "k", "v1")
+	mapSetScalar(m, "k", "v2")
+	if got := mapGet(m, "k"); got == nil || got.Value != "v2" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestMapEnsureMapping_OverwritesNonMapping(t *testing.T) {
+	m := &yaml.Node{Kind: yaml.MappingNode}
+	mapSetNode(m, "profiles", &yaml.Node{Kind: yaml.ScalarNode, Value: "bad"})
+	pm := mapEnsureMapping(m, "profiles")
+	if pm.Kind != yaml.MappingNode {
+		t.Fatalf("expected mapping")
+	}
+}

--- a/internal/platform/config/yamlnode_test.go
+++ b/internal/platform/config/yamlnode_test.go
@@ -1,0 +1,42 @@
+package config
+
+import "testing"
+
+func TestNewEmptyDocument_ViewAndMutations(t *testing.T) {
+	doc := NewEmptyDocument()
+
+	v, err := ViewOf(doc)
+	if err != nil {
+		t.Fatalf("view: %v", err)
+	}
+	if v.CurrentProfile != "" {
+		t.Fatalf("currentProfile: got %q", v.CurrentProfile)
+	}
+
+	doc, err = WithCurrentProfile(doc, "staging")
+	if err != nil {
+		t.Fatalf("with current: %v", err)
+	}
+	doc, err = WithProfileAPIURL(doc, "staging", "https://api")
+	if err != nil {
+		t.Fatalf("with api: %v", err)
+	}
+
+	v, err = ViewOf(doc)
+	if err != nil {
+		t.Fatalf("view2: %v", err)
+	}
+	if v.CurrentProfile != "staging" {
+		t.Fatalf("currentProfile: got %q", v.CurrentProfile)
+	}
+	if v.Profiles["staging"].APIURL != "https://api" {
+		t.Fatalf("apiUrl: got %q", v.Profiles["staging"].APIURL)
+	}
+}
+
+func TestRootMapping_InvalidDocs(t *testing.T) {
+	_, err := rootMapping(Document{})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/ports/out/configstore.go
+++ b/internal/ports/out/configstore.go
@@ -1,0 +1,19 @@
+package out
+
+import (
+	"context"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+)
+
+// ConfigStore persists and loads the CLI configuration.
+//
+// It must preserve unknown YAML fields when saving an existing config.
+//
+// See docs/cli-spec.md "Config and profiles".
+// See docs/architecture.md for layering rules.
+type ConfigStore interface {
+	Path(ctx context.Context) (string, error)
+	Load(ctx context.Context) (config.Document, error)
+	Save(ctx context.Context, doc config.Document) error
+}


### PR DESCRIPTION
Closes #11\n\n- Adds YAML config file store with OS config dir resolution and EBO_CONFIG_DIR override.\n- Preserves unknown YAML fields on rewrite via yaml.Node updates.\n- Adds precedence resolver that uses config currentProfile and profile apiUrl when flags/env don’t override.\n- Adds unit tests and keeps internal coverage >=85%.