### PR TITLE
Planner API outbound port + OpenAPI adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notes:
 ## [Unreleased]
 
 ### Added
+- Added a `plannerapi` outbound port and HTTP adapter wrapping the generated OpenAPI client (auth + idempotency headers + normalized errors).
 - Added deterministic OpenAPI client generation (`make gen`) driven by `spec.lock`.
 - Added YAML-backed config storage with profile support and precedence resolution (preserves unknown fields on rewrite).
 - Added a stable JSON output envelope and standardized exit-code mapping for errors.

--- a/internal/adapters/out/plannerapi/client.go
+++ b/internal/adapters/out/plannerapi/client.go
@@ -1,0 +1,76 @@
+package plannerapi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+type Adapter struct {
+	HTTPClient *http.Client
+}
+
+func (a Adapter) newClient(baseURL string, bearerToken string) (*gen.ClientWithResponses, error) {
+	opts := []gen.ClientOption{}
+	if a.HTTPClient != nil {
+		opts = append(opts, gen.WithHTTPClient(a.HTTPClient))
+	}
+	opts = append(opts, gen.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+		_ = ctx
+		if strings.TrimSpace(bearerToken) != "" {
+			req.Header.Set("Authorization", "Bearer "+bearerToken)
+		}
+		return nil
+	}))
+	return gen.NewClientWithResponses(baseURL, opts...)
+}
+
+func (a Adapter) CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	params := &gen.CreateTripDraftParams{IdempotencyKey: idempotencyKey}
+	resp, err := client.CreateTripDraftWithResponse(ctx, params, req)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON500)
+	}
+	return resp, nil
+}
+
+func (a Adapter) CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	params := &gen.CancelTripParams{IdempotencyKey: idempotencyKey}
+	resp, err := client.CancelTripWithResponse(ctx, tripID, params)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON404, resp.JSON409, resp.JSON422, resp.JSON500)
+	}
+	return resp, nil
+}
+
+func (a Adapter) ListMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.ListMembersParams) (*gen.ListMembersClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	resp, err := client.ListMembersWithResponse(ctx, params)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON500)
+	}
+	return resp, nil
+}

--- a/internal/adapters/out/plannerapi/client_test.go
+++ b/internal/adapters/out/plannerapi/client_test.go
@@ -1,0 +1,100 @@
+package plannerapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+func TestAdapter_SendsAuthorizationHeader(t *testing.T) {
+	seenAuth := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"members":[]}`))
+	}))
+	defer srv.Close()
+
+	a := Adapter{}
+	_, err := a.ListMembers(context.Background(), srv.URL, "tok", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if seenAuth != "Bearer tok" {
+		t.Fatalf("auth: got %q", seenAuth)
+	}
+}
+
+func TestAdapter_IdempotencyHeader_RequiredAndOptional(t *testing.T) {
+	var createKey, cancelKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/trips":
+			createKey = r.Header.Get("Idempotency-Key")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"trip":{"tripId":"t1"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/trips/t1/cancel":
+			cancelKey = r.Header.Get("Idempotency-Key")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(500)
+		}
+	}))
+	defer srv.Close()
+
+	a := Adapter{}
+	_, err := a.CreateTripDraft(context.Background(), srv.URL, "tok", "k1", gen.CreateTripDraftJSONRequestBody{Name: "n"})
+	if err != nil {
+		t.Fatalf("create err: %v", err)
+	}
+	if createKey != "k1" {
+		t.Fatalf("create idempotency: got %q", createKey)
+	}
+
+	_, err = a.CancelTrip(context.Background(), srv.URL, "tok", gen.TripId("t1"), nil)
+	if err != nil {
+		t.Fatalf("cancel err: %v", err)
+	}
+	if cancelKey != "" {
+		t.Fatalf("cancel idempotency: expected empty, got %q", cancelKey)
+	}
+
+	k := "k2"
+	_, err = a.CancelTrip(context.Background(), srv.URL, "tok", gen.TripId("t1"), &k)
+	if err != nil {
+		t.Fatalf("cancel2 err: %v", err)
+	}
+	if cancelKey != "k2" {
+		t.Fatalf("cancel idempotency: expected k2, got %q", cancelKey)
+	}
+}
+
+func TestAdapter_ErrorDecoding_MapsExitKind(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(401)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":      "UNAUTHORIZED",
+				"message":   "nope",
+				"requestId": "req-1",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	a := Adapter{}
+	_, err := a.ListMembers(context.Background(), srv.URL, "tok", nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Auth {
+		t.Fatalf("expected auth exit code, got %d", exitcode.Code(err))
+	}
+}

--- a/internal/adapters/out/plannerapi/errors.go
+++ b/internal/adapters/out/plannerapi/errors.go
@@ -1,0 +1,71 @@
+package plannerapi
+
+import (
+	"fmt"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+type APIError struct {
+	StatusCode int
+	ErrorCode  string
+	Message    string
+	RequestID  string
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.ErrorCode != "" {
+		return fmt.Sprintf("%s: %s", e.ErrorCode, e.Message)
+	}
+	return e.Message
+}
+
+func exitKindForStatus(status int) exitcode.Kind {
+	switch status {
+	case 401:
+		return exitcode.KindAuth
+	case 404:
+		return exitcode.KindNotFound
+	case 409:
+		return exitcode.KindConflict
+	case 422:
+		return exitcode.KindValidation
+	default:
+		if status >= 500 {
+			return exitcode.KindServer
+		}
+		return exitcode.KindUnexpected
+	}
+}
+
+// apiErrorFromAny converts an oapi-codegen error variant into a single error type.
+//
+// In our generated client, error variants like Unauthorized/NotFound/etc are type
+// aliases of ErrorResponse, so we only need to handle *ErrorResponse here.
+func apiErrorFromAny(status int, variants ...any) error {
+	for _, v := range variants {
+		if v == nil {
+			continue
+		}
+		if er, ok := v.(*gen.ErrorResponse); ok {
+			return apiErrorFromErrorResponse(status, er)
+		}
+	}
+	return exitcode.New(exitKindForStatus(status), fmt.Sprintf("http %d", status), nil)
+}
+
+func apiErrorFromErrorResponse(status int, er *gen.ErrorResponse) *exitcode.Error {
+	if er == nil {
+		return exitcode.New(exitKindForStatus(status), fmt.Sprintf("http %d", status), nil)
+	}
+	requestID := ""
+	if er.Error.RequestId != nil {
+		requestID = *er.Error.RequestId
+	}
+	ae := &APIError{StatusCode: status, ErrorCode: er.Error.Code, Message: er.Error.Message, RequestID: requestID}
+	return exitcode.New(exitKindForStatus(status), ae.Error(), ae)
+}

--- a/internal/adapters/out/plannerapi/errors_test.go
+++ b/internal/adapters/out/plannerapi/errors_test.go
@@ -1,0 +1,67 @@
+package plannerapi
+
+import (
+	"errors"
+	"testing"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+func TestExitKindForStatus(t *testing.T) {
+	cases := []struct {
+		status int
+		want   exitcode.Kind
+	}{
+		{401, exitcode.KindAuth},
+		{404, exitcode.KindNotFound},
+		{409, exitcode.KindConflict},
+		{422, exitcode.KindValidation},
+		{500, exitcode.KindServer},
+		{418, exitcode.KindUnexpected},
+	}
+	for _, tc := range cases {
+		if got := exitKindForStatus(tc.status); got != tc.want {
+			t.Fatalf("status %d: got %q want %q", tc.status, got, tc.want)
+		}
+	}
+}
+
+func TestAPIError_ErrorFormatting(t *testing.T) {
+	e := &APIError{ErrorCode: "X", Message: "m"}
+	if e.Error() != "X: m" {
+		t.Fatalf("got %q", e.Error())
+	}
+	e2 := &APIError{Message: "m"}
+	if e2.Error() != "m" {
+		t.Fatalf("got %q", e2.Error())
+	}
+}
+
+func TestApiErrorFromAny_Fallback(t *testing.T) {
+	err := apiErrorFromAny(404, nil)
+	if exitcode.Code(err) != exitcode.NotFound {
+		t.Fatalf("got %d", exitcode.Code(err))
+	}
+}
+
+func TestApiErrorFromErrorResponse_WrapsAPIError(t *testing.T) {
+	rid := "req-1"
+	er := &gen.ErrorResponse{}
+	er.Error.Code = "C"
+	er.Error.Message = "msg"
+	er.Error.RequestId = &rid
+
+	err := apiErrorFromErrorResponse(401, er)
+	var ee *exitcode.Error
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected exitcode.Error")
+	}
+	var ae *APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected APIError unwrap")
+	}
+	if ae.RequestID != "req-1" {
+		t.Fatalf("requestId: got %q", ae.RequestID)
+	}
+}

--- a/internal/ports/out/plannerapi/plannerapi.go
+++ b/internal/ports/out/plannerapi/plannerapi.go
@@ -1,0 +1,22 @@
+package plannerapi
+
+import (
+	"context"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+)
+
+// Client is the outbound port used by the application layer.
+//
+// It wraps the generated OpenAPI client behind a stable interface.
+//
+// Note: this port currently exposes generated types. As the CLI matures,
+// we can introduce domain-level DTOs.
+type Client interface {
+	// Trips
+	CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error)
+	CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error)
+
+	// Members
+	ListMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.ListMembersParams) (*gen.ListMembersClientResponse, error)
+}


### PR DESCRIPTION
Closes #13\n\n- Adds a plannerapi outbound port interface.\n- Implements an HTTP adapter wrapping the generated OpenAPI client with base URL selection, Authorization header injection, correct idempotency header behavior, and normalized error mapping.\n- Adds httptest-based coverage for headers + error mapping.\n\nNote: Generated code remains under internal/gen and is excluded from the coverage gate.