### PR TITLE
Implement ebo config commands (path/get/set/unset/list)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notes:
 ## [Unreleased]
 
 ### Added
+- Added `ebo config` commands (path/get/set/unset/list) with secret redaction and `--include-secrets` for JSON output.
 - Added HTTP runtime helpers for per-request timeouts, verbose request logging, and token redaction.
 - Added an architecture dependency guard test to enforce hex-layer import rules in CI.
 - Added a `plannerapi` outbound port and HTTP adapter wrapping the generated OpenAPI client (auth + idempotency headers + normalized errors).

--- a/cmd/ebo/main.go
+++ b/cmd/ebo/main.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/BennettSmith/ebo-planner-cli/internal/adapters/in/cli"
+	"github.com/BennettSmith/ebo-planner-cli/internal/adapters/out/configfile"
 	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
 	"github.com/BennettSmith/ebo-planner-cli/internal/platform/envelope"
 	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
@@ -16,7 +17,8 @@ func main() {
 	defaults := cliopts.DefaultGlobalOptions()
 	peek := cliopts.PeekGlobalOptions(os.Args[1:], env, defaults)
 
-	cmd := cli.NewRootCmd(cli.RootDeps{Env: env, Stdout: os.Stdout, Stderr: os.Stderr})
+	store := configfile.Store{Env: configfile.OSEnv{}}
+	cmd := cli.NewRootCmd(cli.RootDeps{Env: env, ConfigStore: store, Stdout: os.Stdout, Stderr: os.Stderr})
 	if err := cmd.Execute(); err != nil {
 		// Best-effort classify errors into the required exit code contract.
 		mapped := err

--- a/internal/adapters/in/cli/config_cmd.go
+++ b/internal/adapters/in/cli/config_cmd.go
@@ -1,0 +1,192 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/app/configapp"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/envelope"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	"github.com/spf13/cobra"
+)
+
+func addConfigCommands(root *cobra.Command, deps RootDeps) {
+	svc := configapp.Service{Store: deps.ConfigStore}
+
+	cfgCmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage CLI configuration",
+	}
+
+	cfgCmd.AddCommand(newConfigPathCmd(deps, svc))
+	cfgCmd.AddCommand(newConfigGetCmd(deps, svc))
+	cfgCmd.AddCommand(newConfigSetCmd(deps, svc))
+	cfgCmd.AddCommand(newConfigUnsetCmd(deps, svc))
+	cfgCmd.AddCommand(newConfigListCmd(deps, svc))
+
+	root.AddCommand(cfgCmd)
+}
+
+func resolvedFromRoot(cmd *cobra.Command, deps RootDeps) (cliopts.Resolved, error) {
+	defaults := cliopts.DefaultGlobalOptions()
+	return cliopts.ResolveGlobalOptions(cmd.InheritedFlags(), deps.Env, defaults)
+}
+
+func newConfigPathCmd(deps RootDeps, svc configapp.Service) *cobra.Command {
+	return &cobra.Command{
+		Use:   "path",
+		Short: "Print config file path",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := svc.EnsureStore(); err != nil {
+				return exitcode.New(exitcode.KindUnexpected, "config store", err)
+			}
+			ctx := context.Background()
+			p, err := svc.Path(ctx)
+			if err != nil {
+				return err
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{"path": p},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+			_, _ = io.WriteString(deps.Stdout, p+"\n")
+			return nil
+		},
+	}
+}
+
+func newConfigGetCmd(deps RootDeps, svc configapp.Service) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <key>",
+		Short: "Get a config value by dot-path",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := args[0]
+			ctx := context.Background()
+			val, err := svc.Get(ctx, key)
+			if err != nil {
+				return err
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{"key": key, "value": val},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+			_, _ = io.WriteString(deps.Stdout, val+"\n")
+			return nil
+		},
+	}
+}
+
+func newConfigSetCmd(deps RootDeps, svc configapp.Service) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Set a config value by dot-path",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			key, val := args[0], args[1]
+			if err := svc.Set(ctx, key, val); err != nil {
+				return err
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				outVal := val
+				if strings.Contains(key, "accessToken") {
+					outVal = "REDACTED"
+				}
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{"key": key, "value": outVal},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+			_, _ = io.WriteString(deps.Stdout, "OK\n")
+			return nil
+		},
+	}
+}
+
+func newConfigUnsetCmd(deps RootDeps, svc configapp.Service) *cobra.Command {
+	return &cobra.Command{
+		Use:   "unset <key>",
+		Short: "Remove a config value by dot-path",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			key := args[0]
+			if err := svc.Unset(ctx, key); err != nil {
+				return err
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{"key": key},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+			_, _ = io.WriteString(deps.Stdout, "OK\n")
+			return nil
+		},
+	}
+}
+
+func newConfigListCmd(deps RootDeps, svc configapp.Service) *cobra.Command {
+	var includeSecrets bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Print the entire config file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+
+			if resolved.Options.Output == cliopts.OutputJSON {
+				data, err := svc.ListJSON(ctx, includeSecrets)
+				if err != nil {
+					return err
+				}
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: data,
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+
+			// Table mode always redacts.
+			y, err := svc.ListYAML(ctx, false)
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprint(deps.Stdout, y)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&includeSecrets, "include-secrets", false, "Include secrets in JSON output only")
+	return cmd
+}

--- a/internal/adapters/in/cli/config_cmd_test.go
+++ b/internal/adapters/in/cli/config_cmd_test.go
@@ -1,0 +1,212 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+type memStore struct {
+	path string
+	doc  config.Document
+}
+
+func (m memStore) Path(ctx context.Context) (string, error)             { return m.path, nil }
+func (m memStore) Load(ctx context.Context) (config.Document, error)    { return m.doc, nil }
+func (m *memStore) Save(ctx context.Context, doc config.Document) error { m.doc = doc; return nil }
+
+func TestConfigPath_JSON(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	store := &memStore{path: "/tmp/config.yaml", doc: config.NewEmptyDocument()}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "config", "path"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout not json: %v", err)
+	}
+	data := got["data"].(map[string]any)
+	if data["path"] != "/tmp/config.yaml" {
+		t.Fatalf("path: %#v", data["path"])
+	}
+}
+
+func TestConfigList_RedactsInTable(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.dev.auth.accessToken", "secret")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"config", "list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("secret")) {
+		t.Fatalf("expected redacted")
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("REDACTED")) {
+		t.Fatalf("expected REDACTED marker")
+	}
+}
+
+func TestConfigList_IncludeSecrets_JSONOnly(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.dev.auth.accessToken", "secret")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "config", "list", "--include-secrets"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("secret")) {
+		t.Fatalf("expected secret included in json")
+	}
+}
+
+func TestConfigGet_NotFoundExitCode(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"config", "get", "nope"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.NotFound {
+		t.Fatalf("expected exit 4, got %d", exitcode.Code(err))
+	}
+}
+
+func TestConfigGet_SecretRedacted_Table(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.dev.auth.accessToken", "secret")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"config", "get", "profiles.dev.auth.accessToken"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("secret")) {
+		t.Fatalf("expected redacted")
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("REDACTED")) {
+		t.Fatalf("expected REDACTED")
+	}
+}
+
+func TestConfigSet_JSONRedactsSecretValue(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "config", "set", "profiles.dev.auth.accessToken", "secret"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("secret")) {
+		t.Fatalf("expected secret redacted in json response")
+	}
+}
+
+func TestConfigUnset_JSON(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.dev.apiUrl", "http://x")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "config", "unset", "profiles.dev.apiUrl"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}
+
+func TestConfigList_JSONRedactsByDefault(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.dev.auth.accessToken", "secret")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "config", "list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("secret")) {
+		t.Fatalf("expected redacted")
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("REDACTED")) {
+		t.Fatalf("expected REDACTED")
+	}
+}
+
+func TestConfigSet_TableOKAndPersists(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"config", "set", "profiles.dev.apiUrl", "http://x"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("OK")) {
+		t.Fatalf("expected OK")
+	}
+	// Verify persisted
+	val, err := config.Get(store.doc, "profiles.dev.apiUrl")
+	if err != nil || val != "http://x" {
+		t.Fatalf("val %q err %v", val, err)
+	}
+}
+
+func TestConfigUnset_TableOK(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.dev.apiUrl", "http://x")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"config", "unset", "profiles.dev.apiUrl"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("OK")) {
+		t.Fatalf("expected OK")
+	}
+}
+
+func TestConfigGet_InvalidKeyIsUsage(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"config", "get", "a..b"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected usage, got %d", exitcode.Code(err))
+	}
+}

--- a/internal/adapters/in/cli/root.go
+++ b/internal/adapters/in/cli/root.go
@@ -8,11 +8,14 @@ import (
 	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
 	"github.com/BennettSmith/ebo-planner-cli/internal/platform/envelope"
 	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	"github.com/BennettSmith/ebo-planner-cli/internal/ports/out"
 	"github.com/spf13/cobra"
 )
 
 type RootDeps struct {
 	Env cliopts.EnvProvider
+
+	ConfigStore out.ConfigStore
 
 	Stdout io.Writer
 	Stderr io.Writer
@@ -73,6 +76,8 @@ func NewRootCmd(deps RootDeps) *cobra.Command {
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		return fmt.Errorf("%w", exitcode.New(exitcode.KindUsage, "usage error", err))
 	})
+
+	addConfigCommands(cmd, deps)
 
 	return cmd
 }

--- a/internal/app/configapp/service.go
+++ b/internal/app/configapp/service.go
@@ -1,0 +1,113 @@
+package configapp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	"github.com/BennettSmith/ebo-planner-cli/internal/ports/out"
+)
+
+type Service struct {
+	Store out.ConfigStore
+}
+
+func (s Service) Path(ctx context.Context) (string, error) {
+	p, err := s.Store.Path(ctx)
+	if err != nil {
+		return "", exitcode.New(exitcode.KindServer, "config path", err)
+	}
+	return p, nil
+}
+
+func (s Service) Get(ctx context.Context, key string) (string, error) {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return "", exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	v, err := config.Get(doc, key)
+	if err != nil {
+		if _, ok := err.(config.ErrNotFound); ok {
+			return "", exitcode.New(exitcode.KindNotFound, "config key not found", err)
+		}
+		return "", exitcode.New(exitcode.KindUsage, "invalid config key", err)
+	}
+	if config.IsSecretKey(key) {
+		return "REDACTED", nil
+	}
+	return v, nil
+}
+
+func (s Service) Set(ctx context.Context, key, value string) error {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	doc, err = config.SetString(doc, key, value)
+	if err != nil {
+		return exitcode.New(exitcode.KindUsage, "invalid config key", err)
+	}
+	if err := s.Store.Save(ctx, doc); err != nil {
+		return exitcode.New(exitcode.KindServer, "save config", err)
+	}
+	return nil
+}
+
+func (s Service) Unset(ctx context.Context, key string) error {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	doc, err = config.Unset(doc, key)
+	if err != nil {
+		return exitcode.New(exitcode.KindUsage, "invalid config key", err)
+	}
+	if err := s.Store.Save(ctx, doc); err != nil {
+		return exitcode.New(exitcode.KindServer, "save config", err)
+	}
+	return nil
+}
+
+func (s Service) ListYAML(ctx context.Context, includeSecrets bool) (string, error) {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return "", exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	if !includeSecrets {
+		doc, err = config.RedactSecrets(doc)
+		if err != nil {
+			return "", exitcode.New(exitcode.KindServer, "redact secrets", err)
+		}
+	}
+	b, err := config.MarshalYAML(doc)
+	if err != nil {
+		return "", exitcode.New(exitcode.KindServer, "marshal config", err)
+	}
+	return string(b), nil
+}
+
+func (s Service) ListJSON(ctx context.Context, includeSecrets bool) (any, error) {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	if !includeSecrets {
+		doc, err = config.RedactSecrets(doc)
+		if err != nil {
+			return nil, exitcode.New(exitcode.KindServer, "redact secrets", err)
+		}
+	}
+	m, err := config.ToInterface(doc)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "marshal config", err)
+	}
+	return m, nil
+}
+
+func (s Service) EnsureStore() error {
+	if s.Store == nil {
+		return fmt.Errorf("nil store")
+	}
+	return nil
+}

--- a/internal/app/configapp/service_test.go
+++ b/internal/app/configapp/service_test.go
@@ -1,0 +1,271 @@
+package configapp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+type memStore struct {
+	path  string
+	doc   config.Document
+	saved int
+}
+
+func (m *memStore) Path(ctx context.Context) (string, error)          { return m.path, nil }
+func (m *memStore) Load(ctx context.Context) (config.Document, error) { return m.doc, nil }
+func (m *memStore) Save(ctx context.Context, doc config.Document) error {
+	m.doc = doc
+	m.saved++
+	return nil
+}
+
+func TestService_GetNotFoundIsExit4(t *testing.T) {
+	m := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	s := Service{Store: m}
+	_, err := s.Get(context.Background(), "nope")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.NotFound {
+		t.Fatalf("expected exit 4, got %d", exitcode.Code(err))
+	}
+}
+
+func TestService_SetAndUnsetPersists(t *testing.T) {
+	m := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	s := Service{Store: m}
+	ctx := context.Background()
+
+	if err := s.Set(ctx, "profiles.dev.apiUrl", "http://x"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if m.saved != 1 {
+		t.Fatalf("saved: %d", m.saved)
+	}
+	v, err := config.Get(m.doc, "profiles.dev.apiUrl")
+	if err != nil || v != "http://x" {
+		t.Fatalf("got %q err %v", v, err)
+	}
+
+	if err := s.Unset(ctx, "profiles.dev.apiUrl"); err != nil {
+		t.Fatalf("unset: %v", err)
+	}
+	if m.saved != 2 {
+		t.Fatalf("saved: %d", m.saved)
+	}
+}
+
+func TestService_ListYAML_RedactsByDefault(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.dev.auth.accessToken", "secret")
+	m := &memStore{path: "/x", doc: doc}
+	s := Service{Store: m}
+
+	out, err := s.ListYAML(context.Background(), false)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !contains(out, "REDACTED") {
+		t.Fatalf("expected redacted, got %q", out)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && (func() bool { return stringContains(s, sub) })())
+}
+func stringContains(s, sub string) bool {
+	return (len(sub) == 0) || (len(s) >= len(sub) && (indexOf(s, sub) >= 0))
+}
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestService_GetSecretIsRedacted(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.dev.auth.accessToken", "secret")
+	m := &memStore{path: "/x", doc: doc}
+	s := Service{Store: m}
+
+	val, err := s.Get(context.Background(), "profiles.dev.auth.accessToken")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if val != "REDACTED" {
+		t.Fatalf("got %q", val)
+	}
+}
+
+func TestService_ListJSON_SecretsOptional(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.dev.auth.accessToken", "secret")
+	m := &memStore{path: "/x", doc: doc}
+	s := Service{Store: m}
+
+	red, err := s.ListJSON(context.Background(), false)
+	if err != nil {
+		t.Fatalf("list redacted: %v", err)
+	}
+	b, _ := json.Marshal(red)
+	if string(b) == "" {
+		t.Fatalf("expected json")
+	}
+	if string(b) == "secret" || contains(string(b), "secret") {
+		t.Fatalf("expected redacted")
+	}
+
+	full, err := s.ListJSON(context.Background(), true)
+	if err != nil {
+		t.Fatalf("list full: %v", err)
+	}
+	b2, _ := json.Marshal(full)
+	if !contains(string(b2), "secret") {
+		t.Fatalf("expected secret")
+	}
+}
+
+type errStore struct {
+	loadErr error
+	saveErr error
+	pathErr error
+}
+
+func (e errStore) Path(ctx context.Context) (string, error) { return "", e.pathErr }
+func (e errStore) Load(ctx context.Context) (config.Document, error) {
+	return config.Document{}, e.loadErr
+}
+func (e errStore) Save(ctx context.Context, doc config.Document) error { return e.saveErr }
+
+func TestService_Path(t *testing.T) {
+	m := &memStore{path: "/p", doc: config.NewEmptyDocument()}
+	s := Service{Store: m}
+	p, err := s.Path(context.Background())
+	if err != nil {
+		t.Fatalf("path: %v", err)
+	}
+	if p != "/p" {
+		t.Fatalf("got %q", p)
+	}
+}
+
+func TestService_Path_ErrorIsServer(t *testing.T) {
+	s := Service{Store: errStore{pathErr: context.Canceled}}
+	_, err := s.Path(context.Background())
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Server {
+		t.Fatalf("expected server exit, got %d", exitcode.Code(err))
+	}
+}
+
+func TestService_Set_InvalidKeyIsUsage(t *testing.T) {
+	m := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	s := Service{Store: m}
+	err := s.Set(context.Background(), "a..b", "x")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected usage, got %d", exitcode.Code(err))
+	}
+}
+
+func TestService_ListYAML_IncludeSecrets(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.dev.auth.accessToken", "secret")
+	m := &memStore{path: "/x", doc: doc}
+	s := Service{Store: m}
+
+	out, err := s.ListYAML(context.Background(), true)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !contains(out, "secret") {
+		t.Fatalf("expected secret present")
+	}
+}
+
+func TestService_ListJSON_LoadErrorIsServer(t *testing.T) {
+	s := Service{Store: errStore{loadErr: context.Canceled}}
+	_, err := s.ListJSON(context.Background(), false)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Server {
+		t.Fatalf("expected server, got %d", exitcode.Code(err))
+	}
+}
+
+func TestService_EnsureStore(t *testing.T) {
+	s := Service{}
+	if err := s.EnsureStore(); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+type saveErrStore struct {
+	doc     config.Document
+	saveErr error
+}
+
+func (s *saveErrStore) Path(ctx context.Context) (string, error) { return "/x", nil }
+func (s *saveErrStore) Load(ctx context.Context) (config.Document, error) {
+	return s.doc, nil
+}
+func (s *saveErrStore) Save(ctx context.Context, doc config.Document) error { return s.saveErr }
+
+func TestService_SaveErrorIsServer(t *testing.T) {
+	st := &saveErrStore{doc: config.NewEmptyDocument(), saveErr: context.Canceled}
+	svc := Service{Store: st}
+
+	err := svc.Set(context.Background(), "profiles.dev.apiUrl", "http://x")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Server {
+		t.Fatalf("expected server, got %d", exitcode.Code(err))
+	}
+}
+
+func TestService_Get_InvalidKeyIsUsage(t *testing.T) {
+	m := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	s := Service{Store: m}
+	_, err := s.Get(context.Background(), "a..b")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected usage, got %d", exitcode.Code(err))
+	}
+}
+
+func TestService_Unset_InvalidKeyIsUsage(t *testing.T) {
+	m := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	s := Service{Store: m}
+	err := s.Unset(context.Background(), "a..b")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected usage, got %d", exitcode.Code(err))
+	}
+}
+
+func TestService_Unset_SaveErrorIsServer(t *testing.T) {
+	st := &saveErrStore{doc: config.NewEmptyDocument(), saveErr: context.Canceled}
+	svc := Service{Store: st}
+	if err := svc.Unset(context.Background(), "profiles.dev.apiUrl"); err == nil {
+		t.Fatalf("expected error")
+	} else if exitcode.Code(err) != exitcode.Server {
+		t.Fatalf("expected server, got %d", exitcode.Code(err))
+	}
+}

--- a/internal/platform/config/dotpath.go
+++ b/internal/platform/config/dotpath.go
@@ -1,0 +1,174 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ErrNotFound indicates a missing key path.
+type ErrNotFound struct{ Key string }
+
+func (e ErrNotFound) Error() string { return fmt.Sprintf("key not found: %s", e.Key) }
+
+func splitPath(key string) ([]string, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, fmt.Errorf("empty key")
+	}
+	parts := strings.Split(key, ".")
+	for _, p := range parts {
+		if p == "" {
+			return nil, fmt.Errorf("invalid key %q", key)
+		}
+	}
+	return parts, nil
+}
+
+// Get returns the scalar value at a dot-path key.
+// If the key is missing, ErrNotFound is returned.
+func Get(doc Document, key string) (string, error) {
+	parts, err := splitPath(key)
+	if err != nil {
+		return "", err
+	}
+	root, err := rootMapping(doc)
+	if err != nil {
+		return "", err
+	}
+
+	n := root
+	for i, p := range parts {
+		if n.Kind != yaml.MappingNode {
+			return "", ErrNotFound{Key: key}
+		}
+		v := mapGet(n, p)
+		if v == nil {
+			return "", ErrNotFound{Key: key}
+		}
+		if i == len(parts)-1 {
+			if v.Kind != yaml.ScalarNode {
+				return "", fmt.Errorf("key %s is not a scalar", key)
+			}
+			return v.Value, nil
+		}
+		n = v
+	}
+	return "", ErrNotFound{Key: key}
+}
+
+// SetString sets a scalar string value at a dot-path key, creating missing maps.
+func SetString(doc Document, key string, value string) (Document, error) {
+	parts, err := splitPath(key)
+	if err != nil {
+		return Document{}, err
+	}
+	root, err := rootMapping(doc)
+	if err != nil {
+		return Document{}, err
+	}
+
+	n := root
+	for i, p := range parts {
+		if i == len(parts)-1 {
+			mapSetScalar(n, p, value)
+			return doc, nil
+		}
+		n = mapEnsureMapping(n, p)
+	}
+	return doc, nil
+}
+
+// Unset removes the key at the dot-path.
+// If the key doesn't exist, it is a no-op.
+func Unset(doc Document, key string) (Document, error) {
+	parts, err := splitPath(key)
+	if err != nil {
+		return Document{}, err
+	}
+	root, err := rootMapping(doc)
+	if err != nil {
+		return Document{}, err
+	}
+	_ = unsetAt(root, parts)
+	return doc, nil
+}
+
+func unsetAt(m *yaml.Node, parts []string) bool {
+	if m == nil || m.Kind != yaml.MappingNode || len(parts) == 0 {
+		return false
+	}
+	key := parts[0]
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		k := m.Content[i]
+		v := m.Content[i+1]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			if len(parts) == 1 {
+				// remove key/value
+				m.Content = append(m.Content[:i], m.Content[i+2:]...)
+				return true
+			}
+			// recurse
+			removed := unsetAt(v, parts[1:])
+			return removed
+		}
+	}
+	return false
+}
+
+func IsSecretKey(key string) bool {
+	// Spec-defined secret: profiles.<name>.auth.accessToken
+	parts, err := splitPath(key)
+	if err != nil {
+		return false
+	}
+	if len(parts) >= 4 && parts[0] == "profiles" && parts[2] == "auth" && parts[3] == "accessToken" {
+		return true
+	}
+	return false
+}
+
+// RedactSecrets returns a copy of doc where known secret values are replaced with "REDACTED".
+func RedactSecrets(doc Document) (Document, error) {
+	_, err := rootMapping(doc)
+	if err != nil {
+		return Document{}, err
+	}
+
+	copyRoot := deepCopyNode(doc.Root)
+	out := Document{Root: copyRoot}
+
+	outRoot, _ := rootMapping(out)
+	// Walk known secret paths: profiles.*.auth.accessToken
+	profiles := mapGet(outRoot, "profiles")
+	if profiles == nil || profiles.Kind != yaml.MappingNode {
+		return out, nil
+	}
+	for i := 0; i+1 < len(profiles.Content); i += 2 {
+		pnode := profiles.Content[i+1]
+		auth := mapGet(pnode, "auth")
+		if auth == nil || auth.Kind != yaml.MappingNode {
+			continue
+		}
+		at := mapGet(auth, "accessToken")
+		if at != nil && at.Kind == yaml.ScalarNode {
+			at.Value = "REDACTED"
+		}
+	}
+	return out, nil
+}
+
+func deepCopyNode(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	c := *n
+	if len(n.Content) > 0 {
+		c.Content = make([]*yaml.Node, len(n.Content))
+		for i := range n.Content {
+			c.Content[i] = deepCopyNode(n.Content[i])
+		}
+	}
+	return &c
+}

--- a/internal/platform/config/dotpath_test.go
+++ b/internal/platform/config/dotpath_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestDotPath_SetGetUnset(t *testing.T) {
+	doc := NewEmptyDocument()
+	var err error
+
+	doc, err = SetString(doc, "profiles.dev.apiUrl", "http://x")
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, err := Get(doc, "profiles.dev.apiUrl")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got != "http://x" {
+		t.Fatalf("got %q", got)
+	}
+
+	doc, err = Unset(doc, "profiles.dev.apiUrl")
+	if err != nil {
+		t.Fatalf("unset: %v", err)
+	}
+	if _, err := Get(doc, "profiles.dev.apiUrl"); err == nil {
+		t.Fatalf("expected not found")
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	doc := NewEmptyDocument()
+	if _, err := Get(doc, "nope"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestGet_NonScalar(t *testing.T) {
+	doc := NewEmptyDocument()
+	root := doc.Root.Content[0]
+	mapSetNode(root, "profiles", &yaml.Node{Kind: yaml.MappingNode})
+	if _, err := Get(doc, "profiles"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestRedactSecrets(t *testing.T) {
+	doc := NewEmptyDocument()
+	var err error
+	doc, err = SetString(doc, "profiles.dev.auth.accessToken", "secret")
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	red, err := RedactSecrets(doc)
+	if err != nil {
+		t.Fatalf("redact: %v", err)
+	}
+	got, err := Get(red, "profiles.dev.auth.accessToken")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got != "REDACTED" {
+		t.Fatalf("got %q", got)
+	}
+	orig, _ := Get(doc, "profiles.dev.auth.accessToken")
+	if orig != "secret" {
+		t.Fatalf("original mutated")
+	}
+}
+
+func TestIsSecretKey(t *testing.T) {
+	if !IsSecretKey("profiles.dev.auth.accessToken") {
+		t.Fatalf("expected secret")
+	}
+	if IsSecretKey("profiles.dev.apiUrl") {
+		t.Fatalf("unexpected secret")
+	}
+}
+
+func TestSetString_InvalidKey(t *testing.T) {
+	doc := NewEmptyDocument()
+	if _, err := SetString(doc, "", "x"); err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, err := SetString(doc, "a..b", "x"); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/platform/config/encode.go
+++ b/internal/platform/config/encode.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"bytes"
+
+	"gopkg.in/yaml.v3"
+)
+
+func MarshalYAML(doc Document) ([]byte, error) {
+	return yaml.Marshal(doc.Root)
+}
+
+func ToInterface(doc Document) (any, error) {
+	// Decode yaml.Node into interface{} for JSON output.
+	var v any
+	b, err := MarshalYAML(doc)
+	if err != nil {
+		return nil, err
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(b))
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}

--- a/internal/platform/config/encode_test.go
+++ b/internal/platform/config/encode_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestToInterface(t *testing.T) {
+	doc := NewEmptyDocument()
+	var err error
+	doc, err = SetString(doc, "currentProfile", "default")
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	v, err := ToInterface(doc)
+	if err != nil {
+		t.Fatalf("to interface: %v", err)
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map, got %T", v)
+	}
+	if m["currentProfile"] != "default" {
+		t.Fatalf("got %#v", m["currentProfile"])
+	}
+}


### PR DESCRIPTION
Closes #15\n\n- Adds  commands.\n- Implements dot-path get/set/unset on YAML config while preserving unknown fields.\n- Implements secret redaction in  by default with  allowed only in JSON output.\n- Adds unit tests and keeps internal coverage >=85%.