### PR TITLE
Implement ebo profile commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notes:
 ## [Unreleased]
 
 ### Added
+- `ebo profile` commands: manage profiles (list/show/create/set/use/delete) and switch current profile.
 - Added `ebo config` commands (path/get/set/unset/list) with secret redaction and `--include-secrets` for JSON output.
 - Added HTTP runtime helpers for per-request timeouts, verbose request logging, and token redaction.
 - Added an architecture dependency guard test to enforce hex-layer import rules in CI.

--- a/internal/adapters/in/cli/config_cmd_test.go
+++ b/internal/adapters/in/cli/config_cmd_test.go
@@ -210,3 +210,33 @@ func TestConfigGet_InvalidKeyIsUsage(t *testing.T) {
 		t.Fatalf("expected usage, got %d", exitcode.Code(err))
 	}
 }
+
+func TestConfigPath_Table(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	store := &memStore{path: "/tmp/config.yaml", doc: config.NewEmptyDocument()}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"config", "path"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("/tmp/config.yaml")) {
+		t.Fatalf("expected path, got %q", stdout.String())
+	}
+}
+
+func TestConfigPath_NilStoreIsUnexpectedExitCode(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: nil, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"config", "path"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Unexpected {
+		t.Fatalf("expected unexpected exit 1, got %d", exitcode.Code(err))
+	}
+}

--- a/internal/adapters/in/cli/profile_cmd.go
+++ b/internal/adapters/in/cli/profile_cmd.go
@@ -1,0 +1,222 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/app/profileapp"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/envelope"
+	"github.com/spf13/cobra"
+)
+
+func addProfileCommands(root *cobra.Command, deps RootDeps) {
+	svc := profileapp.Service{Store: deps.ConfigStore}
+
+	profileCmd := &cobra.Command{
+		Use:   "profile",
+		Short: "Manage named profiles and select the active profile",
+	}
+
+	profileCmd.AddCommand(newProfileListCmd(deps, svc))
+	profileCmd.AddCommand(newProfileShowCmd(deps, svc))
+	profileCmd.AddCommand(newProfileCreateCmd(deps, svc))
+	profileCmd.AddCommand(newProfileSetCmd(deps, svc))
+	profileCmd.AddCommand(newProfileUseCmd(deps, svc))
+	profileCmd.AddCommand(newProfileDeleteCmd(deps, svc))
+
+	root.AddCommand(profileCmd)
+}
+
+func newProfileListCmd(deps RootDeps, svc profileapp.Service) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List profiles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			profiles, current, err := svc.List(ctx)
+			if err != nil {
+				return err
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{
+						"currentProfile": current,
+						"profiles":       profiles,
+					},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+
+			_, _ = io.WriteString(deps.Stdout, "NAME\tAPI URL\tCURRENT\n")
+			for _, p := range profiles {
+				mark := ""
+				if p.Name == current {
+					mark = "*"
+				}
+				_, _ = fmt.Fprintf(deps.Stdout, "%s\t%s\t%s\n", p.Name, p.APIURL, mark)
+			}
+			return nil
+		},
+	}
+}
+
+func newProfileShowCmd(deps RootDeps, svc profileapp.Service) *cobra.Command {
+	return &cobra.Command{
+		Use:   "show [profile]",
+		Short: "Show a profile (defaults to current profile)",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := ""
+			if len(args) == 1 {
+				name = args[0]
+			}
+
+			ctx := context.Background()
+			p, err := svc.Show(ctx, name)
+			if err != nil {
+				return err
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{"profile": p},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+
+			_, _ = fmt.Fprintf(deps.Stdout, "Name: %s\nAPI URL: %s\n", p.Name, p.APIURL)
+			return nil
+		},
+	}
+}
+
+func newProfileCreateCmd(deps RootDeps, svc profileapp.Service) *cobra.Command {
+	var apiURL string
+	cmd := &cobra.Command{
+		Use:   "create <profile> --api-url <url>",
+		Short: "Create a new profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			ctx := context.Background()
+			if err := svc.Create(ctx, name, apiURL); err != nil {
+				return err
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{"profile": name, "apiUrl": apiURL},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+			_, _ = io.WriteString(deps.Stdout, "OK\n")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&apiURL, "api-url", "", "Planner API base URL")
+	_ = cmd.MarkFlagRequired("api-url")
+	return cmd
+}
+
+func newProfileSetCmd(deps RootDeps, svc profileapp.Service) *cobra.Command {
+	var apiURL string
+	cmd := &cobra.Command{
+		Use:   "set <profile> --api-url <url>",
+		Short: "Set profile fields (creates profile if missing)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			ctx := context.Background()
+			if err := svc.SetAPIURL(ctx, name, apiURL); err != nil {
+				return err
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{"profile": name, "apiUrl": apiURL},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+			_, _ = io.WriteString(deps.Stdout, "OK\n")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&apiURL, "api-url", "", "Planner API base URL")
+	_ = cmd.MarkFlagRequired("api-url")
+	return cmd
+}
+
+func newProfileUseCmd(deps RootDeps, svc profileapp.Service) *cobra.Command {
+	return &cobra.Command{
+		Use:   "use <profile>",
+		Short: "Set the current profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			ctx := context.Background()
+			if err := svc.Use(ctx, name); err != nil {
+				return err
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{"currentProfile": name},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+			_, _ = io.WriteString(deps.Stdout, "OK\n")
+			return nil
+		},
+	}
+}
+
+func newProfileDeleteCmd(deps RootDeps, svc profileapp.Service) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <profile>",
+		Short: "Delete a profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			ctx := context.Background()
+			if err := svc.Delete(ctx, name); err != nil {
+				return err
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{"deleted": name},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+			_, _ = io.WriteString(deps.Stdout, "OK\n")
+			return nil
+		},
+	}
+}

--- a/internal/adapters/in/cli/profile_cmd_test.go
+++ b/internal/adapters/in/cli/profile_cmd_test.go
@@ -1,0 +1,283 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+func TestProfileList_JSON(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	doc, _ = config.WithProfileAPIURL(doc, "dev", "http://b")
+	doc, _ = config.WithCurrentProfile(doc, "dev")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "profile", "list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout not json: %v", err)
+	}
+	data := got["data"].(map[string]any)
+	if data["currentProfile"] != "dev" {
+		t.Fatalf("currentProfile: %#v", data["currentProfile"])
+	}
+	profiles := data["profiles"].([]any)
+	if len(profiles) != 2 {
+		t.Fatalf("profiles len: %d", len(profiles))
+	}
+}
+
+func TestProfileShow_Table(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"profile", "show", "default"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("Name: default")) {
+		t.Fatalf("expected Name line, got %q", stdout.String())
+	}
+}
+
+func TestProfileCreate_ConflictExitCode(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "dev", "http://x")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"profile", "create", "dev", "--api-url", "http://y"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Conflict {
+		t.Fatalf("expected conflict exit 5, got %d", exitcode.Code(err))
+	}
+}
+
+func TestProfileUse_MissingIsUsageExitCode(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"profile", "use", "nope"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected usage exit 2, got %d", exitcode.Code(err))
+	}
+}
+
+func TestProfileDelete_LastProfileConflictExitCode(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"profile", "delete", "default"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Conflict {
+		t.Fatalf("expected conflict exit 5, got %d", exitcode.Code(err))
+	}
+}
+
+func TestProfileDelete_CurrentProfileSwitchesToDefault(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	doc, _ = config.WithProfileAPIURL(doc, "dev", "http://b")
+	doc, _ = config.WithCurrentProfile(doc, "dev")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"profile", "delete", "dev"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	v, _ := config.ViewOf(store.doc)
+	if v.CurrentProfile != "default" {
+		t.Fatalf("currentProfile: got %q", v.CurrentProfile)
+	}
+	if _, ok := v.Profiles["dev"]; ok {
+		t.Fatalf("expected dev profile deleted")
+	}
+}
+
+func TestProfileSet_CreatesIfMissing(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"profile", "set", "staging", "--api-url", "http://s"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	v, _ := config.ViewOf(store.doc)
+	if v.Profiles["staging"].APIURL != "http://s" {
+		t.Fatalf("apiUrl: got %q", v.Profiles["staging"].APIURL)
+	}
+}
+
+func TestProfileList_Table(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"profile", "list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("NAME")) {
+		t.Fatalf("expected header, got %q", stdout.String())
+	}
+}
+
+func TestProfileCreate_Success_JSONPersists(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "profile", "create", "dev", "--api-url", "http://x"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	val, err := config.Get(store.doc, "profiles.dev.apiUrl")
+	if err != nil || val != "http://x" {
+		t.Fatalf("persisted apiUrl %q err %v", val, err)
+	}
+}
+
+func TestProfileShow_JSON(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "profile", "show", "default"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("\"profile\"")) {
+		t.Fatalf("expected json profile object, got %q", stdout.String())
+	}
+}
+
+func TestProfileUse_Success_JSON(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "profile", "use", "default"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	v, _ := config.ViewOf(store.doc)
+	if v.CurrentProfile != "default" {
+		t.Fatalf("currentProfile: got %q", v.CurrentProfile)
+	}
+}
+
+func TestProfileDelete_JSON(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	doc, _ = config.WithProfileAPIURL(doc, "dev", "http://b")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "profile", "delete", "dev"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("\"deleted\"")) {
+		t.Fatalf("expected deleted field, got %q", stdout.String())
+	}
+}
+
+func TestProfileCreate_TableOK(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"profile", "create", "dev", "--api-url", "http://x"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("OK")) {
+		t.Fatalf("expected OK, got %q", stdout.String())
+	}
+}
+
+func TestProfileUse_TableOK(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	store := &memStore{path: "/x", doc: doc}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"profile", "use", "default"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("OK")) {
+		t.Fatalf("expected OK, got %q", stdout.String())
+	}
+}
+
+func TestProfileSet_JSON(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "profile", "set", "staging", "--api-url", "http://s"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("\"apiUrl\"")) {
+		t.Fatalf("expected apiUrl in json, got %q", stdout.String())
+	}
+}

--- a/internal/adapters/in/cli/root.go
+++ b/internal/adapters/in/cli/root.go
@@ -78,6 +78,7 @@ func NewRootCmd(deps RootDeps) *cobra.Command {
 	})
 
 	addConfigCommands(cmd, deps)
+	addProfileCommands(cmd, deps)
 
 	return cmd
 }

--- a/internal/app/profileapp/service.go
+++ b/internal/app/profileapp/service.go
@@ -1,0 +1,170 @@
+package profileapp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	"github.com/BennettSmith/ebo-planner-cli/internal/ports/out"
+)
+
+type Service struct {
+	Store out.ConfigStore
+}
+
+type ProfileSummary struct {
+	Name   string
+	APIURL string
+}
+
+func (s Service) List(ctx context.Context) ([]ProfileSummary, string, error) {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return nil, "", exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	v, err := config.ViewOf(doc)
+	if err != nil {
+		return nil, "", exitcode.New(exitcode.KindServer, "parse config", err)
+	}
+	current := v.CurrentProfile
+	if current == "" {
+		current = "default"
+	}
+
+	outList := make([]ProfileSummary, 0, len(v.Profiles))
+	for name, p := range v.Profiles {
+		outList = append(outList, ProfileSummary{Name: name, APIURL: p.APIURL})
+	}
+	sort.Slice(outList, func(i, j int) bool { return outList[i].Name < outList[j].Name })
+	return outList, current, nil
+}
+
+func (s Service) Show(ctx context.Context, name string) (ProfileSummary, error) {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return ProfileSummary{}, exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	v, err := config.ViewOf(doc)
+	if err != nil {
+		return ProfileSummary{}, exitcode.New(exitcode.KindServer, "parse config", err)
+	}
+
+	if name == "" {
+		name = v.CurrentProfile
+		if name == "" {
+			name = "default"
+		}
+	}
+	p, ok := v.Profiles[name]
+	if !ok {
+		return ProfileSummary{}, exitcode.New(exitcode.KindUsage, "profile does not exist", fmt.Errorf("%s", name))
+	}
+	return ProfileSummary{Name: name, APIURL: p.APIURL}, nil
+}
+
+func (s Service) Create(ctx context.Context, name, apiURL string) error {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	v, err := config.ViewOf(doc)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "parse config", err)
+	}
+	if _, ok := v.Profiles[name]; ok {
+		return exitcode.New(exitcode.KindConflict, "profile already exists", fmt.Errorf("%s", name))
+	}
+	doc, err = config.WithProfileAPIURL(doc, name, apiURL)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "update config", err)
+	}
+	if err := s.Store.Save(ctx, doc); err != nil {
+		return exitcode.New(exitcode.KindServer, "save config", err)
+	}
+	return nil
+}
+
+func (s Service) SetAPIURL(ctx context.Context, name, apiURL string) error {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	doc, err = config.WithProfileAPIURL(doc, name, apiURL)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "update config", err)
+	}
+	if err := s.Store.Save(ctx, doc); err != nil {
+		return exitcode.New(exitcode.KindServer, "save config", err)
+	}
+	return nil
+}
+
+func (s Service) Use(ctx context.Context, name string) error {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	v, err := config.ViewOf(doc)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "parse config", err)
+	}
+	if _, ok := v.Profiles[name]; !ok {
+		return exitcode.New(exitcode.KindUsage, "profile does not exist", fmt.Errorf("%s", name))
+	}
+	doc, err = config.WithCurrentProfile(doc, name)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "update config", err)
+	}
+	if err := s.Store.Save(ctx, doc); err != nil {
+		return exitcode.New(exitcode.KindServer, "save config", err)
+	}
+	return nil
+}
+
+func (s Service) Delete(ctx context.Context, name string) error {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	v, err := config.ViewOf(doc)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "parse config", err)
+	}
+	if _, ok := v.Profiles[name]; !ok {
+		return exitcode.New(exitcode.KindConflict, "profile does not exist", fmt.Errorf("%s", name))
+	}
+
+	// Cannot delete last profile.
+	if len(v.Profiles) <= 1 {
+		return exitcode.New(exitcode.KindConflict, "cannot delete last profile; create another profile first", nil)
+	}
+
+	// Remove profiles.<name>
+	doc, err = config.Unset(doc, "profiles."+name)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "update config", err)
+	}
+
+	// If deleting current profile, switch to default if it exists.
+	current := v.CurrentProfile
+	if current == "" {
+		current = "default"
+	}
+	if current == name {
+		if _, ok := v.Profiles["default"]; ok && name != "default" {
+			doc, err = config.WithCurrentProfile(doc, "default")
+			if err != nil {
+				return exitcode.New(exitcode.KindServer, "update config", err)
+			}
+		} else {
+			return exitcode.New(exitcode.KindConflict, "cannot delete current profile; create a default profile (or switch currentProfile first)", nil)
+		}
+	}
+
+	if err := s.Store.Save(ctx, doc); err != nil {
+		return exitcode.New(exitcode.KindServer, "save config", err)
+	}
+	return nil
+}

--- a/internal/app/profileapp/service_test.go
+++ b/internal/app/profileapp/service_test.go
@@ -1,0 +1,170 @@
+package profileapp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+type memStore struct {
+	doc config.Document
+}
+
+func (m *memStore) Path(ctx context.Context) (string, error)            { return "/x", nil }
+func (m *memStore) Load(ctx context.Context) (config.Document, error)   { return m.doc, nil }
+func (m *memStore) Save(ctx context.Context, doc config.Document) error { m.doc = doc; return nil }
+
+func TestList_DefaultCurrentProfileWhenUnset(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	doc, _ = config.WithProfileAPIURL(doc, "dev", "http://b")
+
+	m := &memStore{doc: doc}
+	s := Service{Store: m}
+
+	list, current, err := s.List(context.Background())
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if current != "default" {
+		t.Fatalf("current: got %q", current)
+	}
+	if len(list) != 2 {
+		t.Fatalf("list size: got %d", len(list))
+	}
+}
+
+func TestShow_DefaultsToCurrentProfileOrDefault(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	doc, _ = config.WithProfileAPIURL(doc, "dev", "http://b")
+	doc, _ = config.WithCurrentProfile(doc, "dev")
+
+	m := &memStore{doc: doc}
+	s := Service{Store: m}
+
+	got, err := s.Show(context.Background(), "")
+	if err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if got.Name != "dev" {
+		t.Fatalf("name: got %q", got.Name)
+	}
+	if got.APIURL != "http://b" {
+		t.Fatalf("apiUrl: got %q", got.APIURL)
+	}
+}
+
+func TestCreateConflict(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "dev", "http://x")
+
+	m := &memStore{doc: doc}
+	s := Service{Store: m}
+	if err := s.Create(context.Background(), "dev", "http://y"); err == nil {
+		t.Fatalf("expected error")
+	} else if exitcode.Code(err) != exitcode.Conflict {
+		t.Fatalf("expected conflict, got %d", exitcode.Code(err))
+	}
+}
+
+func TestSetAPIURL_CreatesIfMissing(t *testing.T) {
+	m := &memStore{doc: config.NewEmptyDocument()}
+	s := Service{Store: m}
+
+	if err := s.SetAPIURL(context.Background(), "new", "http://x"); err != nil {
+		t.Fatalf("set api url: %v", err)
+	}
+	v, _ := config.ViewOf(m.doc)
+	if v.Profiles["new"].APIURL != "http://x" {
+		t.Fatalf("apiUrl: got %q", v.Profiles["new"].APIURL)
+	}
+}
+
+func TestUseMissingIsUsage(t *testing.T) {
+	m := &memStore{doc: config.NewEmptyDocument()}
+	s := Service{Store: m}
+	if err := s.Use(context.Background(), "nope"); err == nil {
+		t.Fatalf("expected error")
+	} else if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected usage, got %d", exitcode.Code(err))
+	}
+}
+
+func TestUse_SetsCurrentProfile(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "dev", "http://x")
+	m := &memStore{doc: doc}
+	s := Service{Store: m}
+
+	if err := s.Use(context.Background(), "dev"); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	v, _ := config.ViewOf(m.doc)
+	if v.CurrentProfile != "dev" {
+		t.Fatalf("currentProfile: got %q", v.CurrentProfile)
+	}
+}
+
+func TestDeleteLastProfileConflict(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://x")
+	m := &memStore{doc: doc}
+	s := Service{Store: m}
+	if err := s.Delete(context.Background(), "default"); err == nil {
+		t.Fatalf("expected error")
+	} else if exitcode.Code(err) != exitcode.Conflict {
+		t.Fatalf("expected conflict")
+	}
+}
+
+func TestDelete_CurrentProfileSwitchesToDefault(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://a")
+	doc, _ = config.WithProfileAPIURL(doc, "dev", "http://b")
+	doc, _ = config.WithCurrentProfile(doc, "dev")
+
+	m := &memStore{doc: doc}
+	s := Service{Store: m}
+
+	if err := s.Delete(context.Background(), "dev"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	v, _ := config.ViewOf(m.doc)
+	if v.CurrentProfile != "default" {
+		t.Fatalf("currentProfile: got %q", v.CurrentProfile)
+	}
+	if _, ok := v.Profiles["dev"]; ok {
+		t.Fatalf("expected dev profile deleted")
+	}
+}
+
+func TestCreate_SuccessPersists(t *testing.T) {
+	m := &memStore{doc: config.NewEmptyDocument()}
+	s := Service{Store: m}
+
+	if err := s.Create(context.Background(), "dev", "http://x"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	v, _ := config.ViewOf(m.doc)
+	if v.Profiles["dev"].APIURL != "http://x" {
+		t.Fatalf("apiUrl: got %q", v.Profiles["dev"].APIURL)
+	}
+}
+
+func TestDelete_CurrentWithoutDefaultConflict(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithProfileAPIURL(doc, "dev", "http://x")
+	doc, _ = config.WithProfileAPIURL(doc, "staging", "http://y")
+	doc, _ = config.WithCurrentProfile(doc, "dev")
+
+	m := &memStore{doc: doc}
+	s := Service{Store: m}
+	if err := s.Delete(context.Background(), "dev"); err == nil {
+		t.Fatalf("expected error")
+	} else if exitcode.Code(err) != exitcode.Conflict {
+		t.Fatalf("expected conflict, got %d", exitcode.Code(err))
+	}
+}

--- a/internal/platform/cliopts/options_test.go
+++ b/internal/platform/cliopts/options_test.go
@@ -169,3 +169,14 @@ func TestResolveGlobalOptions_Validation(t *testing.T) {
 		}
 	})
 }
+
+func TestOSEnv_LookupEnv(t *testing.T) {
+	t.Setenv("EBO_TEST_LOOKUP", "yes")
+	v, ok := (OSEnv{}).LookupEnv("EBO_TEST_LOOKUP")
+	if !ok {
+		t.Fatalf("expected ok")
+	}
+	if v != "yes" {
+		t.Fatalf("expected yes, got %q", v)
+	}
+}

--- a/internal/platform/config/dotpath_test.go
+++ b/internal/platform/config/dotpath_test.go
@@ -89,3 +89,13 @@ func TestSetString_InvalidKey(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 }
+
+func TestErrNotFound_ErrorString(t *testing.T) {
+	err := ErrNotFound{Key: "a.b"}
+	if got := err.Error(); got == "" {
+		t.Fatalf("expected non-empty error")
+	}
+	if got := err.Error(); got != "key not found: a.b" {
+		t.Fatalf("got %q", got)
+	}
+}


### PR DESCRIPTION
Closes #16.

## Summary
- Adds `ebo profile` commands: list/show/create/set/use/delete.
- Enforces exit-code contract for conflict/usage cases.
- Supports both table and JSON output.

## Notes for reviewer
- `make ci` passes locally (internal coverage >= 85%).
