### PR TITLE
Auth token commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notes:
 ## [Unreleased]
 
 ### Added
+- `ebo auth` token commands: `auth status`, `auth logout`, `auth token set`, and `auth token print`.
 - `ebo profile` commands: manage profiles (list/show/create/set/use/delete) and switch current profile.
 - Added `ebo config` commands (path/get/set/unset/list) with secret redaction and `--include-secrets` for JSON output.
 - Added HTTP runtime helpers for per-request timeouts, verbose request logging, and token redaction.

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ci: changelog-verify
 			exit 1; \
 		fi; \
 		go vet ./...; \
-		go test ./... -count=1; \
+		go list ./... | grep -v '/e2e$$' | xargs go test -count=1; \
 		covfile="$$(mktemp)"; \
 		pkgs="$$(go list ./internal/... | grep -v '/internal/gen')"; \
 		go test $$pkgs -count=1 -coverprofile="$$covfile" >/dev/null; \
@@ -61,3 +61,6 @@ gen:
 	@spec_path="$$(go run ./tools/specpin)"; \
 		echo "Generating OpenAPI client from $$spec_path..."; \
 		go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.5.1 -response-type-suffix ClientResponse -config oapi-codegen.yaml "$$spec_path"
+
+e2e:
+	@go test ./e2e -count=1

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -1,0 +1,169 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+var eboPath string
+
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "ebo-e2e-*")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmp)
+
+	bin := filepath.Join(tmp, "ebo")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+
+	cmd := exec.Command("go", "build", "-o", bin, "../cmd/ebo")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		os.Exit(1)
+	}
+
+	eboPath = bin
+	os.Exit(m.Run())
+}
+
+type runResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+func runEBO(t *testing.T, env map[string]string, args ...string) runResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, eboPath, args...)
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			code = ee.ExitCode()
+		} else {
+			code = 1
+		}
+	}
+	return runResult{Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: code}
+}
+
+func TestAuthTokenCommands_E2E(t *testing.T) {
+	cfgDir := t.TempDir()
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(api.Close)
+
+	env := map[string]string{
+		"EBO_CONFIG_DIR": cfgDir,
+		"EBO_NO_COLOR":   "1",
+		"EBO_API_URL":    api.URL,
+	}
+
+	// status (no token) -> exit 3
+	res := runEBO(t, env, "auth", "status")
+	if res.ExitCode != 3 {
+		t.Fatalf("status exit=%d stderr=%q", res.ExitCode, res.Stderr)
+	}
+
+	// token set
+	res = runEBO(t, env, "auth", "token", "set", "--token", "a.b.c")
+	if res.ExitCode != 0 {
+		t.Fatalf("token set exit=%d stderr=%q", res.ExitCode, res.Stderr)
+	}
+	if strings.Contains(res.Stdout, "a.b.c") || strings.Contains(res.Stderr, "a.b.c") {
+		t.Fatalf("token leaked in set output")
+	}
+
+	// token status json
+	res = runEBO(t, env, "--output", "json", "auth", "status")
+	if res.ExitCode != 0 {
+		t.Fatalf("status json exit=%d stderr=%q", res.ExitCode, res.Stderr)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &got); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, res.Stdout)
+	}
+	data := got["data"].(map[string]any)
+	if data["tokenConfigured"] != true {
+		t.Fatalf("tokenConfigured=%#v", data["tokenConfigured"])
+	}
+
+	// token print (table) -> stdout only, no stderr
+	res = runEBO(t, env, "auth", "token", "print")
+	if res.ExitCode != 0 {
+		t.Fatalf("print exit=%d stderr=%q", res.ExitCode, res.Stderr)
+	}
+	if strings.TrimSpace(res.Stdout) != "a.b.c" {
+		t.Fatalf("stdout=%q", res.Stdout)
+	}
+	if res.Stderr != "" {
+		t.Fatalf("expected no stderr, got %q", res.Stderr)
+	}
+
+	// token print (json) -> simple json object
+	res = runEBO(t, env, "--output", "json", "auth", "token", "print")
+	if res.ExitCode != 0 {
+		t.Fatalf("print json exit=%d stderr=%q", res.ExitCode, res.Stderr)
+	}
+	if res.Stderr != "" {
+		t.Fatalf("expected no stderr, got %q", res.Stderr)
+	}
+	var tokObj map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &tokObj); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, res.Stdout)
+	}
+	if tokObj["token"] != "a.b.c" {
+		t.Fatalf("token=%#v", tokObj["token"])
+	}
+
+	// logout clears
+	res = runEBO(t, env, "auth", "logout")
+	if res.ExitCode != 0 {
+		t.Fatalf("logout exit=%d stderr=%q", res.ExitCode, res.Stderr)
+	}
+	if strings.Contains(res.Stdout, "a.b.c") || strings.Contains(res.Stderr, "a.b.c") {
+		t.Fatalf("token leaked in logout output")
+	}
+
+	// print missing -> exit 3, token not printed
+	res = runEBO(t, env, "auth", "token", "print")
+	if res.ExitCode != 3 {
+		t.Fatalf("print missing exit=%d", res.ExitCode)
+	}
+	if strings.Contains(res.Stdout, "a.b.c") || strings.Contains(res.Stderr, "a.b.c") {
+		t.Fatalf("token leaked when missing")
+	}
+}

--- a/internal/adapters/in/cli/auth_cmd.go
+++ b/internal/adapters/in/cli/auth_cmd.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/app/authapp"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/envelope"
+	"github.com/spf13/cobra"
+)
+
+func addAuthCommands(root *cobra.Command, deps RootDeps) {
+	svc := authapp.Service{Store: deps.ConfigStore}
+
+	authCmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Authentication helpers",
+	}
+
+	authCmd.AddCommand(newAuthStatusCmd(deps, svc))
+	authCmd.AddCommand(newAuthLogoutCmd(deps, svc))
+	authCmd.AddCommand(newAuthTokenCmd(deps, svc))
+
+	root.AddCommand(authCmd)
+}
+
+func newAuthStatusCmd(deps RootDeps, svc authapp.Service) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show whether a token is configured for the active profile",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			st, err := svc.Status(ctx)
+			if err != nil {
+				return err
+			}
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{
+						"profile":         st.Profile,
+						"tokenConfigured": st.TokenConfigured,
+						"tokenType":       st.TokenType,
+						"expiresAt":       st.ExpiresAt,
+					},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+			// Single-line output.
+			state := "not configured"
+			if st.TokenConfigured {
+				state = "configured"
+			}
+			_, _ = fmt.Fprintf(deps.Stdout, "profile=%s token=%s\n", st.Profile, state)
+			return nil
+		},
+	}
+}
+
+func newAuthLogoutCmd(deps RootDeps, svc authapp.Service) *cobra.Command {
+	return &cobra.Command{
+		Use:   "logout",
+		Short: "Clear stored token fields for the active profile",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			if err := svc.Logout(ctx); err != nil {
+				return err
+			}
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{"ok": true},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+			_, _ = io.WriteString(deps.Stdout, "OK\n")
+			return nil
+		},
+	}
+}
+
+func newAuthTokenCmd(deps RootDeps, svc authapp.Service) *cobra.Command {
+	tokenCmd := &cobra.Command{
+		Use:   "token",
+		Short: "Manage stored bearer tokens",
+	}
+
+	tokenCmd.AddCommand(newAuthTokenSetCmd(deps, svc))
+	tokenCmd.AddCommand(newAuthTokenPrintCmd(deps, svc))
+	return tokenCmd
+}
+
+func newAuthTokenSetCmd(deps RootDeps, svc authapp.Service) *cobra.Command {
+	var token string
+	cmd := &cobra.Command{
+		Use:   "set --token <jwt>",
+		Short: "Store a bearer access token for the active profile",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			if err := svc.TokenSet(ctx, "", token); err != nil {
+				return err
+			}
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: map[string]any{"ok": true},
+					Meta: envelope.Meta{APIURL: resolved.Options.APIURL, Profile: resolved.Options.Profile},
+				})
+			}
+			_, _ = io.WriteString(deps.Stdout, "OK\n")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&token, "token", "", "Bearer JWT")
+	_ = cmd.MarkFlagRequired("token")
+	return cmd
+}
+
+func newAuthTokenPrintCmd(deps RootDeps, svc authapp.Service) *cobra.Command {
+	return &cobra.Command{
+		Use:   "print",
+		Short: "Print the current token to stdout (only when explicitly requested)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			tok, _, err := svc.TokenPrint(ctx)
+			if err != nil {
+				return err
+			}
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+
+			// Special-case: must be stdout-only (no extra noise). In JSON mode we still output a single JSON object.
+			if resolved.Options.Output == cliopts.OutputJSON {
+				b, _ := json.Marshal(map[string]any{"token": tok})
+				_, _ = deps.Stdout.Write(append(b, '\n'))
+				return nil
+			}
+			_, _ = io.WriteString(deps.Stdout, tok+"\n")
+			return nil
+		},
+	}
+}

--- a/internal/adapters/in/cli/auth_cmd_test.go
+++ b/internal/adapters/in/cli/auth_cmd_test.go
@@ -1,0 +1,228 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+func TestAuthTokenSet_InvalidJWTIsUsageExit2(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"auth", "token", "set", "--token", "nope"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected usage exit 2, got %d", exitcode.Code(err))
+	}
+}
+
+func TestAuthStatus_NoTokenIsAuthExit3(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"auth", "status"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Auth {
+		t.Fatalf("expected auth exit 3, got %d", exitcode.Code(err))
+	}
+}
+
+func TestAuthLogout_NoTokenIsAuthExit3(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"auth", "logout"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Auth {
+		t.Fatalf("expected auth exit 3, got %d", exitcode.Code(err))
+	}
+}
+
+func TestAuthTokenPrint_JSONIsSimpleObject(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.default.auth.accessToken", "a.b.c")
+	store := &memStore{path: "/x", doc: doc}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "auth", "token", "print"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got %q", stderr.String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout not json: %v", err)
+	}
+	if got["token"] != "a.b.c" {
+		t.Fatalf("token: %#v", got["token"])
+	}
+}
+
+func TestAuthTokenSet_OK_TableDoesNotLeakToken(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"auth", "token", "set", "--token", "a.b.c"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("a.b.c")) || bytes.Contains(stderr.Bytes(), []byte("a.b.c")) {
+		t.Fatalf("token leaked")
+	}
+}
+
+func TestAuthStatus_OK_TableSingleLine(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.default.auth.accessToken", "a.b.c")
+	store := &memStore{path: "/x", doc: doc}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"auth", "status"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if bytes.Count(stdout.Bytes(), []byte("\n")) != 1 {
+		t.Fatalf("expected single line, got %q", stdout.String())
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("a.b.c")) || bytes.Contains(stderr.Bytes(), []byte("a.b.c")) {
+		t.Fatalf("token leaked")
+	}
+}
+
+func TestAuthLogout_OK_JSON(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.default.auth.accessToken", "a.b.c")
+	store := &memStore{path: "/x", doc: doc}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "auth", "logout"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("a.b.c")) || bytes.Contains(stderr.Bytes(), []byte("a.b.c")) {
+		t.Fatalf("token leaked")
+	}
+}
+
+func TestAuthStatus_OK_JSON(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.default.auth.accessToken", "a.b.c")
+	store := &memStore{path: "/x", doc: doc}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "auth", "status"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("a.b.c")) || bytes.Contains(stderr.Bytes(), []byte("a.b.c")) {
+		t.Fatalf("token leaked")
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout not json: %v", err)
+	}
+	data := got["data"].(map[string]any)
+	if data["tokenConfigured"] != true {
+		t.Fatalf("tokenConfigured=%#v", data["tokenConfigured"])
+	}
+	if data["profile"] != "default" {
+		t.Fatalf("profile=%#v", data["profile"])
+	}
+}
+
+func TestAuthLogout_OK_Table(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.default.auth.accessToken", "a.b.c")
+	store := &memStore{path: "/x", doc: doc}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"auth", "logout"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("OK")) {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("a.b.c")) || bytes.Contains(stderr.Bytes(), []byte("a.b.c")) {
+		t.Fatalf("token leaked")
+	}
+}
+
+func TestAuthTokenSet_OK_JSON(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "auth", "token", "set", "--token", "a.b.c"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("a.b.c")) || bytes.Contains(stderr.Bytes(), []byte("a.b.c")) {
+		t.Fatalf("token leaked")
+	}
+}
+
+func TestAuthTokenPrint_Table(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.default.auth.accessToken", "a.b.c")
+	store := &memStore{path: "/x", doc: doc}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"auth", "token", "print"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got %q", stderr.String())
+	}
+	if string(bytes.TrimSpace(stdout.Bytes())) != "a.b.c" {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+}
+
+func TestAuthTokenPrint_MissingIsAuthExit3(t *testing.T) {
+	store := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := NewRootCmd(RootDeps{Env: nil, ConfigStore: store, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"auth", "token", "print"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Auth {
+		t.Fatalf("expected auth exit 3, got %d", exitcode.Code(err))
+	}
+}

--- a/internal/adapters/in/cli/root.go
+++ b/internal/adapters/in/cli/root.go
@@ -79,6 +79,7 @@ func NewRootCmd(deps RootDeps) *cobra.Command {
 
 	addConfigCommands(cmd, deps)
 	addProfileCommands(cmd, deps)
+	addAuthCommands(cmd, deps)
 
 	return cmd
 }

--- a/internal/app/authapp/service.go
+++ b/internal/app/authapp/service.go
@@ -1,0 +1,159 @@
+package authapp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	"github.com/BennettSmith/ebo-planner-cli/internal/ports/out"
+)
+
+type Service struct {
+	Store out.ConfigStore
+}
+
+type Status struct {
+	Profile         string
+	TokenConfigured bool
+	TokenType       string
+	ExpiresAt       string
+}
+
+func (s Service) Status(ctx context.Context) (Status, error) {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return Status{}, exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	v, err := config.ViewOf(doc)
+	if err != nil {
+		return Status{}, exitcode.New(exitcode.KindServer, "parse config", err)
+	}
+	profile := v.CurrentProfile
+	if profile == "" {
+		profile = "default"
+	}
+
+	accessToken, _ := config.Get(doc, "profiles."+profile+".auth.accessToken")
+	tokenType, _ := config.Get(doc, "profiles."+profile+".auth.tokenType")
+	expiresAt, _ := config.Get(doc, "profiles."+profile+".auth.expiresAt")
+
+	configured := strings.TrimSpace(accessToken) != ""
+	st := Status{Profile: profile, TokenConfigured: configured, TokenType: tokenType, ExpiresAt: expiresAt}
+	if !configured {
+		return st, exitcode.New(exitcode.KindAuth, "no token configured", nil)
+	}
+	return st, nil
+}
+
+func (s Service) Logout(ctx context.Context) error {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	v, err := config.ViewOf(doc)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "parse config", err)
+	}
+	profile := v.CurrentProfile
+	if profile == "" {
+		profile = "default"
+	}
+
+	accessToken, _ := config.Get(doc, "profiles."+profile+".auth.accessToken")
+	if strings.TrimSpace(accessToken) == "" {
+		return exitcode.New(exitcode.KindAuth, "no token configured", nil)
+	}
+
+	doc, err = config.Unset(doc, "profiles."+profile+".auth.accessToken")
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "update config", err)
+	}
+	doc, err = config.Unset(doc, "profiles."+profile+".auth.tokenType")
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "update config", err)
+	}
+	doc, err = config.Unset(doc, "profiles."+profile+".auth.expiresAt")
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "update config", err)
+	}
+
+	if err := s.Store.Save(ctx, doc); err != nil {
+		return exitcode.New(exitcode.KindServer, "save config", err)
+	}
+	return nil
+}
+
+func (s Service) TokenSet(ctx context.Context, profile string, token string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return exitcode.New(exitcode.KindUsage, "empty token", nil)
+	}
+	if !looksLikeJWT(token) {
+		return exitcode.New(exitcode.KindUsage, "token must look like a JWT (three dot-separated parts)", nil)
+	}
+
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "load config", err)
+	}
+
+	if profile == "" {
+		v, err := config.ViewOf(doc)
+		if err != nil {
+			return exitcode.New(exitcode.KindServer, "parse config", err)
+		}
+		profile = v.CurrentProfile
+		if profile == "" {
+			profile = "default"
+		}
+	}
+
+	doc, err = config.SetString(doc, "profiles."+profile+".auth.accessToken", token)
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "update config", err)
+	}
+	doc, err = config.SetString(doc, "profiles."+profile+".auth.tokenType", "Bearer")
+	if err != nil {
+		return exitcode.New(exitcode.KindServer, "update config", err)
+	}
+
+	if err := s.Store.Save(ctx, doc); err != nil {
+		return exitcode.New(exitcode.KindServer, "save config", err)
+	}
+	return nil
+}
+
+func (s Service) TokenPrint(ctx context.Context) (string, string, error) {
+	doc, err := s.Store.Load(ctx)
+	if err != nil {
+		return "", "", exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	v, err := config.ViewOf(doc)
+	if err != nil {
+		return "", "", exitcode.New(exitcode.KindServer, "parse config", err)
+	}
+	profile := v.CurrentProfile
+	if profile == "" {
+		profile = "default"
+	}
+
+	token, err := config.Get(doc, "profiles."+profile+".auth.accessToken")
+	if err != nil || strings.TrimSpace(token) == "" {
+		return "", profile, exitcode.New(exitcode.KindAuth, "no token configured", nil)
+	}
+	return token, profile, nil
+}
+
+func looksLikeJWT(token string) bool {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, p := range parts {
+		if p == "" {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/app/authapp/service_test.go
+++ b/internal/app/authapp/service_test.go
@@ -1,0 +1,124 @@
+package authapp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+type memStore struct{ doc config.Document }
+
+func (m memStore) Path(ctx context.Context) (string, error)             { return "/x", nil }
+func (m memStore) Load(ctx context.Context) (config.Document, error)    { return m.doc, nil }
+func (m *memStore) Save(ctx context.Context, doc config.Document) error { m.doc = doc; return nil }
+
+func TestTokenSet_ValidatesJWTShape(t *testing.T) {
+	s := Service{Store: &memStore{doc: config.NewEmptyDocument()}}
+	if err := s.TokenSet(context.Background(), "default", "notajwt"); err == nil {
+		t.Fatalf("expected error")
+	} else if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected usage, got %d", exitcode.Code(err))
+	}
+}
+
+func TestTokenSet_PersistsAccessTokenAndTokenType(t *testing.T) {
+	m := &memStore{doc: config.NewEmptyDocument()}
+	s := Service{Store: m}
+
+	tok := "a.b.c"
+	if err := s.TokenSet(context.Background(), "default", tok); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, _ := config.Get(m.doc, "profiles.default.auth.accessToken")
+	if got != tok {
+		t.Fatalf("token: got %q", got)
+	}
+	tt, _ := config.Get(m.doc, "profiles.default.auth.tokenType")
+	if tt != "Bearer" {
+		t.Fatalf("tokenType: got %q", tt)
+	}
+	if _, err := config.Get(m.doc, "profiles.default.auth.expiresAt"); err == nil {
+		t.Fatalf("expected expiresAt untouched")
+	}
+}
+
+func TestStatus_NoTokenIsAuthError3(t *testing.T) {
+	m := &memStore{doc: config.NewEmptyDocument()}
+	s := Service{Store: m}
+	_, err := s.Status(context.Background())
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Auth {
+		t.Fatalf("expected auth exit 3, got %d", exitcode.Code(err))
+	}
+}
+
+func TestLogout_NoTokenIsAuthError3(t *testing.T) {
+	m := &memStore{doc: config.NewEmptyDocument()}
+	s := Service{Store: m}
+	err := s.Logout(context.Background())
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Auth {
+		t.Fatalf("expected auth exit 3, got %d", exitcode.Code(err))
+	}
+}
+
+func TestLogout_ClearsFields(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.default.auth.accessToken", "a.b.c")
+	doc, _ = config.SetString(doc, "profiles.default.auth.tokenType", "Bearer")
+	doc, _ = config.SetString(doc, "profiles.default.auth.expiresAt", "2026-01-01T00:00:00Z")
+
+	m := &memStore{doc: doc}
+	s := Service{Store: m}
+	if err := s.Logout(context.Background()); err != nil {
+		t.Fatalf("logout: %v", err)
+	}
+	if _, err := config.Get(m.doc, "profiles.default.auth.accessToken"); err == nil {
+		t.Fatalf("expected token removed")
+	}
+	if _, err := config.Get(m.doc, "profiles.default.auth.tokenType"); err == nil {
+		t.Fatalf("expected tokenType removed")
+	}
+	if _, err := config.Get(m.doc, "profiles.default.auth.expiresAt"); err == nil {
+		t.Fatalf("expected expiresAt removed")
+	}
+}
+
+func TestTokenPrint_Success(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.SetString(doc, "profiles.default.auth.accessToken", "a.b.c")
+	m := &memStore{doc: doc}
+	s := Service{Store: m}
+
+	tok, profile, err := s.TokenPrint(context.Background())
+	if err != nil {
+		t.Fatalf("print: %v", err)
+	}
+	if profile != "default" {
+		t.Fatalf("profile: %q", profile)
+	}
+	if tok != "a.b.c" {
+		t.Fatalf("token: %q", tok)
+	}
+}
+
+func TestTokenSet_UsesCurrentProfileWhenEmpty(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithCurrentProfile(doc, "dev")
+	m := &memStore{doc: doc}
+	s := Service{Store: m}
+
+	if err := s.TokenSet(context.Background(), "", "a.b.c"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, _ := config.Get(m.doc, "profiles.dev.auth.accessToken")
+	if got != "a.b.c" {
+		t.Fatalf("token: %q", got)
+	}
+}

--- a/internal/app/configapp/service_test.go
+++ b/internal/app/configapp/service_test.go
@@ -206,9 +206,17 @@ func TestService_ListJSON_LoadErrorIsServer(t *testing.T) {
 }
 
 func TestService_EnsureStore(t *testing.T) {
+	// nil store
 	s := Service{}
 	if err := s.EnsureStore(); err == nil {
 		t.Fatalf("expected error")
+	}
+
+	// non-nil store
+	m := &memStore{path: "/x", doc: config.NewEmptyDocument()}
+	s = Service{Store: m}
+	if err := s.EnsureStore(); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #17.

## Summary
- Adds `ebo auth status`, `ebo auth logout`, `ebo auth token set --token <jwt>`, and `ebo auth token print`.
- Enforces exit-code + redaction guarantees (token never printed except `token print`).
- Adds an `e2e` test harness that executes the real `ebo` binary.
- Adds `make e2e` (kept separate from `make ci`).

## Verification
- `make ci`
- `make e2e`
