### PR TITLE
feat: add --from-file request mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Notes:
 - `ebo auth` token commands: `auth status`, `auth logout`, `auth token set`, and `auth token print`.
 - `ebo profile` commands: manage profiles (list/show/create/set/use/delete) and switch current profile.
 - Added `ebo config` commands (path/get/set/unset/list) with secret redaction and `--include-secrets` for JSON output.
+- Added `--from-file <path>` JSON/YAML request mode for `ebo trip create`, `ebo trip update`, and `ebo member update`.
 - Added HTTP runtime helpers for per-request timeouts, verbose request logging, and token redaction.
 - Added an architecture dependency guard test to enforce hex-layer import rules in CI.
 - Added a `plannerapi` outbound port and HTTP adapter wrapping the generated OpenAPI client (auth + idempotency headers + normalized errors).

--- a/internal/adapters/in/cli/api_common.go
+++ b/internal/adapters/in/cli/api_common.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+type apiContext struct {
+	Profile     string
+	APIURL      string
+	BearerToken string
+}
+
+func resolveAPIContext(ctx context.Context, deps RootDeps, resolved cliopts.Resolved) (apiContext, error) {
+	if deps.ConfigStore == nil {
+		return apiContext{}, exitcode.New(exitcode.KindUnexpected, "config store", fmt.Errorf("nil store"))
+	}
+	doc, err := deps.ConfigStore.Load(ctx)
+	if err != nil {
+		return apiContext{}, exitcode.New(exitcode.KindServer, "load config", err)
+	}
+	view, err := config.ViewOf(doc)
+	if err != nil {
+		return apiContext{}, exitcode.New(exitcode.KindServer, "parse config", err)
+	}
+
+	eff := config.ResolveEffective(resolved, view)
+	if strings.TrimSpace(eff.APIURL) == "" {
+		return apiContext{}, exitcode.New(
+			exitcode.KindUsage,
+			fmt.Sprintf("missing api url (set one with `ebo profile set %s --api-url <url>` or pass --api-url)", eff.Profile),
+			nil,
+		)
+	}
+
+	tok, err := config.Get(doc, "profiles."+eff.Profile+".auth.accessToken")
+	if err != nil {
+		var nf config.ErrNotFound
+		if errors.As(err, &nf) {
+			return apiContext{}, exitcode.New(exitcode.KindAuth, "no token configured (try `ebo auth login`)", nil)
+		}
+		return apiContext{}, exitcode.New(exitcode.KindServer, "read token from config", err)
+	}
+	if strings.TrimSpace(tok) == "" {
+		return apiContext{}, exitcode.New(exitcode.KindAuth, "no token configured (try `ebo auth login`)", nil)
+	}
+
+	return apiContext{Profile: eff.Profile, APIURL: eff.APIURL, BearerToken: tok}, nil
+}
+
+// NOTE: additional shared API helpers belong here as the command surface grows.

--- a/internal/adapters/in/cli/member_cmd.go
+++ b/internal/adapters/in/cli/member_cmd.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/envelope"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/idempotency"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/requestfile"
+	"github.com/spf13/cobra"
+)
+
+func addMemberCommands(root *cobra.Command, deps RootDeps) {
+	memberCmd := &cobra.Command{
+		Use:   "member",
+		Short: "Member operations",
+	}
+	memberCmd.AddCommand(newMemberUpdateCmd(deps))
+	root.AddCommand(memberCmd)
+}
+
+func newMemberUpdateCmd(deps RootDeps) *cobra.Command {
+	var (
+		fromFile       string
+		idempotencyKey string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update my member profile (patch)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = args
+			ctx := context.Background()
+
+			if deps.PlannerAPI == nil {
+				return exitcode.New(exitcode.KindUnexpected, "planner api", fmt.Errorf("nil planner api client"))
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			apiCtx, err := resolveAPIContext(ctx, deps, resolved)
+			if err != nil {
+				return err
+			}
+
+			if strings.TrimSpace(fromFile) == "" {
+				return exitcode.New(exitcode.KindUsage, "missing input (use --from-file)", nil)
+			}
+
+			var req gen.UpdateMyMemberProfileRequest
+			if err := requestfile.LoadStrict(fromFile, &req); err != nil {
+				return exitcode.New(exitcode.KindUsage, "parse request file", err)
+			}
+
+			if strings.TrimSpace(idempotencyKey) == "" {
+				idempotencyKey = idempotency.NewKey()
+			}
+
+			resp, err := deps.PlannerAPI.UpdateMyMemberProfile(ctx, apiCtx.APIURL, apiCtx.BearerToken, idempotencyKey, req)
+			if err != nil {
+				return err
+			}
+
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: resp.JSON200,
+					Meta: envelope.Meta{APIURL: apiCtx.APIURL, Profile: apiCtx.Profile, IdempotencyKey: idempotencyKey},
+				})
+			}
+
+			_, _ = fmt.Fprintf(deps.Stderr, "Idempotency-Key: %s\n", idempotencyKey)
+			_, _ = io.WriteString(deps.Stdout, "OK\n")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Read request body from file (JSON or YAML)")
+	cmd.Flags().StringVar(&idempotencyKey, "idempotency-key", "", "Idempotency key (auto-generated if omitted)")
+
+	return cmd
+}

--- a/internal/adapters/in/cli/root.go
+++ b/internal/adapters/in/cli/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/BennettSmith/ebo-planner-cli/internal/platform/envelope"
 	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
 	"github.com/BennettSmith/ebo-planner-cli/internal/ports/out"
+	outplannerapi "github.com/BennettSmith/ebo-planner-cli/internal/ports/out/plannerapi"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +18,7 @@ type RootDeps struct {
 	Env cliopts.EnvProvider
 
 	ConfigStore out.ConfigStore
+	PlannerAPI  outplannerapi.Client
 
 	Stdout io.Writer
 	Stderr io.Writer
@@ -85,6 +87,8 @@ func NewRootCmd(deps RootDeps) *cobra.Command {
 	addConfigCommands(cmd, deps)
 	addProfileCommands(cmd, deps)
 	addAuthCommands(cmd, deps)
+	addTripCommands(cmd, deps)
+	addMemberCommands(cmd, deps)
 
 	return cmd
 }

--- a/internal/adapters/in/cli/trip_cmd.go
+++ b/internal/adapters/in/cli/trip_cmd.go
@@ -1,0 +1,169 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/envelope"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/idempotency"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/requestfile"
+	"github.com/spf13/cobra"
+)
+
+func addTripCommands(root *cobra.Command, deps RootDeps) {
+	tripCmd := &cobra.Command{
+		Use:   "trip",
+		Short: "Trip operations",
+	}
+
+	tripCmd.AddCommand(newTripCreateCmd(deps))
+	tripCmd.AddCommand(newTripUpdateCmd(deps))
+
+	root.AddCommand(tripCmd)
+}
+
+func newTripCreateCmd(deps RootDeps) *cobra.Command {
+	var (
+		name           string
+		fromFile       string
+		idempotencyKey string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a draft trip",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = args
+			ctx := context.Background()
+
+			if deps.PlannerAPI == nil {
+				return exitcode.New(exitcode.KindUnexpected, "planner api", fmt.Errorf("nil planner api client"))
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			apiCtx, err := resolveAPIContext(ctx, deps, resolved)
+			if err != nil {
+				return err
+			}
+
+			if strings.TrimSpace(name) != "" && strings.TrimSpace(fromFile) != "" {
+				return exitcode.New(exitcode.KindUsage, "choose exactly one of --name or --from-file", nil)
+			}
+
+			var req gen.CreateTripDraftRequest
+			switch {
+			case strings.TrimSpace(fromFile) != "":
+				if err := requestfile.LoadStrict(fromFile, &req); err != nil {
+					return exitcode.New(exitcode.KindUsage, "parse request file", err)
+				}
+			case strings.TrimSpace(name) != "":
+				req = gen.CreateTripDraftRequest{Name: name}
+			default:
+				return exitcode.New(exitcode.KindUsage, "missing input (use --name or --from-file)", nil)
+			}
+
+			if strings.TrimSpace(idempotencyKey) == "" {
+				idempotencyKey = idempotency.NewKey()
+			}
+
+			resp, err := deps.PlannerAPI.CreateTripDraft(ctx, apiCtx.APIURL, apiCtx.BearerToken, idempotencyKey, req)
+			if err != nil {
+				return err
+			}
+
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: resp.JSON201,
+					Meta: envelope.Meta{APIURL: apiCtx.APIURL, Profile: apiCtx.Profile, IdempotencyKey: idempotencyKey},
+				})
+			}
+
+			// Keep stdout clean-ish but still human-friendly.
+			_, _ = fmt.Fprintf(deps.Stderr, "Idempotency-Key: %s\n", idempotencyKey)
+			if resp.JSON201 != nil {
+				_, _ = fmt.Fprintf(deps.Stdout, "tripId=%s\n", resp.JSON201.Trip.TripId)
+			} else {
+				_, _ = io.WriteString(deps.Stdout, "OK\n")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Trip name")
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Read request body from file (JSON or YAML)")
+	cmd.Flags().StringVar(&idempotencyKey, "idempotency-key", "", "Idempotency key (auto-generated if omitted)")
+
+	return cmd
+}
+
+func newTripUpdateCmd(deps RootDeps) *cobra.Command {
+	var (
+		fromFile       string
+		idempotencyKey string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <tripId>",
+		Short: "Update a trip (patch)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			if deps.PlannerAPI == nil {
+				return exitcode.New(exitcode.KindUnexpected, "planner api", fmt.Errorf("nil planner api client"))
+			}
+
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			apiCtx, err := resolveAPIContext(ctx, deps, resolved)
+			if err != nil {
+				return err
+			}
+
+			if strings.TrimSpace(fromFile) == "" {
+				return exitcode.New(exitcode.KindUsage, "missing input (use --from-file)", nil)
+			}
+
+			var req gen.UpdateTripRequest
+			if err := requestfile.LoadStrict(fromFile, &req); err != nil {
+				return exitcode.New(exitcode.KindUsage, "parse request file", err)
+			}
+
+			if strings.TrimSpace(idempotencyKey) == "" {
+				idempotencyKey = idempotency.NewKey()
+			}
+
+			tripID := gen.TripId(args[0])
+			resp, err := deps.PlannerAPI.UpdateTrip(ctx, apiCtx.APIURL, apiCtx.BearerToken, tripID, idempotencyKey, req)
+			if err != nil {
+				return err
+			}
+
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: resp.JSON200,
+					Meta: envelope.Meta{APIURL: apiCtx.APIURL, Profile: apiCtx.Profile, IdempotencyKey: idempotencyKey},
+				})
+			}
+
+			_, _ = fmt.Fprintf(deps.Stderr, "Idempotency-Key: %s\n", idempotencyKey)
+			_, _ = io.WriteString(deps.Stdout, "OK\n")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Read request body from file (JSON or YAML)")
+	cmd.Flags().StringVar(&idempotencyKey, "idempotency-key", "", "Idempotency key (auto-generated if omitted)")
+
+	return cmd
+}

--- a/internal/adapters/in/cli/trip_member_fromfile_test.go
+++ b/internal/adapters/in/cli/trip_member_fromfile_test.go
@@ -1,0 +1,418 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	outplannerapi "github.com/BennettSmith/ebo-planner-cli/internal/ports/out/plannerapi"
+)
+
+type fakePlannerAPI struct {
+	createCalls int
+	updateCalls int
+	memberCalls int
+
+	lastCreateIdem string
+	lastUpdateIdem string
+	lastMemberIdem string
+
+	lastCreateReq gen.CreateTripDraftJSONRequestBody
+	lastUpdateReq gen.UpdateTripJSONRequestBody
+	lastMemberReq gen.UpdateMyMemberProfileJSONRequestBody
+}
+
+var _ outplannerapi.Client = (*fakePlannerAPI)(nil)
+
+func (f *fakePlannerAPI) CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	f.createCalls++
+	f.lastCreateIdem = idempotencyKey
+	f.lastCreateReq = req
+	return &gen.CreateTripDraftClientResponse{JSON201: &gen.CreateTripDraftResponse{Trip: gen.TripCreated{TripId: "t1"}}}, nil
+}
+
+func (f *fakePlannerAPI) UpdateTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.UpdateTripJSONRequestBody) (*gen.UpdateTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	f.updateCalls++
+	f.lastUpdateIdem = idempotencyKey
+	f.lastUpdateReq = req
+	return &gen.UpdateTripClientResponse{JSON200: &gen.TripResponse{}}, nil
+}
+
+func (f *fakePlannerAPI) CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = idempotencyKey
+	return &gen.CancelTripClientResponse{}, nil
+}
+
+func (f *fakePlannerAPI) ListMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.ListMembersParams) (*gen.ListMembersClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = params
+	return &gen.ListMembersClientResponse{}, nil
+}
+
+func (f *fakePlannerAPI) UpdateMyMemberProfile(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.UpdateMyMemberProfileJSONRequestBody) (*gen.UpdateMyMemberProfileClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	f.memberCalls++
+	f.lastMemberIdem = idempotencyKey
+	f.lastMemberReq = req
+	return &gen.UpdateMyMemberProfileClientResponse{JSON200: &gen.UpdateMyMemberProfileResponse{}}, nil
+}
+
+func writeTempFile(t *testing.T, name string, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	return p
+}
+
+func baseDoc(t *testing.T) config.Document {
+	t.Helper()
+	doc := config.NewEmptyDocument()
+	var err error
+	doc, err = config.WithCurrentProfile(doc, "default")
+	if err != nil {
+		t.Fatalf("current profile: %v", err)
+	}
+	doc, err = config.WithProfileAPIURL(doc, "default", "http://api")
+	if err != nil {
+		t.Fatalf("api url: %v", err)
+	}
+	doc, err = config.SetString(doc, "profiles.default.auth.accessToken", "tok")
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	return doc
+}
+
+func TestTripCreate_FromFile_ParseError_NoAPICall_Exit2(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	p := writeTempFile(t, "bad.json", "{")
+	cmd.SetArgs([]string{"trip", "create", "--from-file", p})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.createCalls != 0 {
+		t.Fatalf("expected no API calls, got %d", api.createCalls)
+	}
+}
+
+func TestTripUpdate_FromFile_ParseError_NoAPICall_Exit2(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	p := writeTempFile(t, "bad.yaml", ":\n- nope")
+	cmd.SetArgs([]string{"trip", "update", "t1", "--from-file", p})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.updateCalls != 0 {
+		t.Fatalf("expected no API calls, got %d", api.updateCalls)
+	}
+}
+
+func TestMemberUpdate_FromFile_ParseError_NoAPICall_Exit2(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	p := writeTempFile(t, "bad.json", "{")
+	cmd.SetArgs([]string{"member", "update", "--from-file", p})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.memberCalls != 0 {
+		t.Fatalf("expected no API calls, got %d", api.memberCalls)
+	}
+}
+
+func TestTripCreate_FromFile_MapsToRequestStruct(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	p := writeTempFile(t, "trip.yaml", "name: Trip From File\n")
+	cmd.SetArgs([]string{"trip", "create", "--from-file", p, "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.createCalls != 1 {
+		t.Fatalf("expected 1 API call, got %d", api.createCalls)
+	}
+	if api.lastCreateReq.Name != "Trip From File" {
+		t.Fatalf("name: %q", api.lastCreateReq.Name)
+	}
+}
+
+func TestTripCreate_NameFlag_MapsToRequestStruct(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "create", "--name", "Trip From Flag", "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.createCalls != 1 {
+		t.Fatalf("expected 1 API call, got %d", api.createCalls)
+	}
+	if api.lastCreateReq.Name != "Trip From Flag" {
+		t.Fatalf("name: %q", api.lastCreateReq.Name)
+	}
+	if api.lastCreateIdem != "k1" {
+		t.Fatalf("idempotency: %q", api.lastCreateIdem)
+	}
+}
+
+func TestTripCreate_BothNameAndFromFile_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	p := writeTempFile(t, "trip.yaml", "name: Trip From File\n")
+	cmd.SetArgs([]string{"trip", "create", "--name", "x", "--from-file", p})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d", exitcode.Code(err))
+	}
+	if api.createCalls != 0 {
+		t.Fatalf("expected no API calls, got %d", api.createCalls)
+	}
+}
+
+func TestTripCreate_AutoGeneratesIdempotencyKey_WhenOmitted(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "create", "--name", "Trip", "--output", "table"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.createCalls != 1 {
+		t.Fatalf("expected 1 API call, got %d", api.createCalls)
+	}
+	if api.lastCreateIdem == "" {
+		t.Fatalf("expected idempotency key generated")
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("Idempotency-Key: ")) {
+		t.Fatalf("expected idempotency printed to stderr, got: %q", stderr.String())
+	}
+}
+
+func TestTripUpdate_FromFile_Success_MapsToRequestStruct(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	p := writeTempFile(t, "patch.yaml", "description: |\n  a\n  b\n")
+	cmd.SetArgs([]string{"trip", "update", "t1", "--from-file", p, "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.updateCalls != 1 {
+		t.Fatalf("expected 1 API call, got %d", api.updateCalls)
+	}
+	if api.lastUpdateIdem != "k1" {
+		t.Fatalf("idempotency: %q", api.lastUpdateIdem)
+	}
+	if api.lastUpdateReq.Description == nil || *api.lastUpdateReq.Description != "a\nb\n" {
+		if api.lastUpdateReq.Description == nil {
+			t.Fatalf("expected description set")
+		}
+		t.Fatalf("description: %#v", *api.lastUpdateReq.Description)
+	}
+}
+
+func TestMemberUpdate_FromFile_Success_MapsToRequestStruct(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	p := writeTempFile(t, "member.yaml", "displayName: New Name\n")
+	cmd.SetArgs([]string{"member", "update", "--from-file", p, "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.memberCalls != 1 {
+		t.Fatalf("expected 1 API call, got %d", api.memberCalls)
+	}
+	if api.lastMemberIdem != "k1" {
+		t.Fatalf("idempotency: %q", api.lastMemberIdem)
+	}
+	if api.lastMemberReq.DisplayName == nil || *api.lastMemberReq.DisplayName != "New Name" {
+		if api.lastMemberReq.DisplayName == nil {
+			t.Fatalf("expected displayName set")
+		}
+		t.Fatalf("displayName: %#v", *api.lastMemberReq.DisplayName)
+	}
+}
+
+func TestTripCreate_MissingAPIURL_IsUsage(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithCurrentProfile(doc, "default")
+	// no apiUrl configured
+	doc, _ = config.SetString(doc, "profiles.default.auth.accessToken", "tok")
+	store := &memStore{path: "/x", doc: doc}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "create", "--name", "Trip", "--idempotency-key", "k1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.createCalls != 0 {
+		t.Fatalf("expected no API calls, got %d", api.createCalls)
+	}
+}
+
+func TestTripCreate_MissingToken_IsAuth(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithCurrentProfile(doc, "default")
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://api")
+	// no token configured
+	store := &memStore{path: "/x", doc: doc}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "create", "--name", "Trip", "--idempotency-key", "k1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Auth {
+		t.Fatalf("expected exit 3, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.createCalls != 0 {
+		t.Fatalf("expected no API calls, got %d", api.createCalls)
+	}
+}
+
+func TestTripUpdate_MissingFromFile_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "update", "t1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d", exitcode.Code(err))
+	}
+	if api.updateCalls != 0 {
+		t.Fatalf("expected no API calls, got %d", api.updateCalls)
+	}
+}
+
+func TestMemberUpdate_MissingFromFile_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d", exitcode.Code(err))
+	}
+	if api.memberCalls != 0 {
+		t.Fatalf("expected no API calls, got %d", api.memberCalls)
+	}
+}
+
+func TestTripCreate_JSONOutput_IncludesMetaIdempotencyKey(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "trip", "create", "--name", "Trip", "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	meta := env["meta"].(map[string]any)
+	if meta["idempotencyKey"] != "k1" {
+		t.Fatalf("idempotencyKey: %#v", meta["idempotencyKey"])
+	}
+}

--- a/internal/adapters/out/plannerapi/client.go
+++ b/internal/adapters/out/plannerapi/client.go
@@ -51,6 +51,22 @@ func (a Adapter) CreateTripDraft(ctx context.Context, baseURL string, bearerToke
 	return resp, nil
 }
 
+func (a Adapter) UpdateTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.UpdateTripJSONRequestBody) (*gen.UpdateTripClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	params := &gen.UpdateTripParams{IdempotencyKey: idempotencyKey}
+	resp, err := client.UpdateTripWithResponse(ctx, tripID, params, req)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON404, resp.JSON409, resp.JSON422, resp.JSON500)
+	}
+	return resp, nil
+}
+
 func (a Adapter) CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error) {
 	client, err := a.newClient(baseURL, bearerToken)
 	if err != nil {
@@ -78,6 +94,22 @@ func (a Adapter) ListMembers(ctx context.Context, baseURL string, bearerToken st
 	}
 	if resp.StatusCode() >= 400 {
 		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON500)
+	}
+	return resp, nil
+}
+
+func (a Adapter) UpdateMyMemberProfile(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.UpdateMyMemberProfileJSONRequestBody) (*gen.UpdateMyMemberProfileClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	params := &gen.UpdateMyMemberProfileParams{IdempotencyKey: idempotencyKey}
+	resp, err := client.UpdateMyMemberProfileWithResponse(ctx, params, req)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON404, resp.JSON409, resp.JSON422, resp.JSON500)
 	}
 	return resp, nil
 }

--- a/internal/platform/browseropen/open.go
+++ b/internal/platform/browseropen/open.go
@@ -12,18 +12,23 @@ type Opener interface {
 
 type DefaultOpener struct{}
 
+var (
+	goos        = runtime.GOOS
+	execCommand = exec.Command
+)
+
 func (DefaultOpener) Open(url string) error {
 	if url == "" {
 		return fmt.Errorf("empty url")
 	}
 	var cmd *exec.Cmd
-	switch runtime.GOOS {
+	switch goos {
 	case "darwin":
-		cmd = exec.Command("open", url)
+		cmd = execCommand("open", url)
 	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+		cmd = execCommand("rundll32", "url.dll,FileProtocolHandler", url)
 	default:
-		cmd = exec.Command("xdg-open", url)
+		cmd = execCommand("xdg-open", url)
 	}
 	return cmd.Start()
 }

--- a/internal/platform/browseropen/open_test.go
+++ b/internal/platform/browseropen/open_test.go
@@ -1,9 +1,60 @@
 package browseropen
 
-import "testing"
+import (
+	"os/exec"
+	"testing"
+)
 
 func TestDefaultOpener_EmptyURLIsError(t *testing.T) {
 	if err := (DefaultOpener{}).Open(""); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestDefaultOpener_CommandSelection(t *testing.T) {
+	oldGOOS := goos
+	oldExec := execCommand
+	t.Cleanup(func() {
+		goos = oldGOOS
+		execCommand = oldExec
+	})
+
+	type tc struct {
+		goos     string
+		wantName string
+		wantArgs []string
+	}
+	cases := []tc{
+		{goos: "darwin", wantName: "open", wantArgs: []string{"http://example"}},
+		{goos: "windows", wantName: "rundll32", wantArgs: []string{"url.dll,FileProtocolHandler", "http://example"}},
+		{goos: "linux", wantName: "xdg-open", wantArgs: []string{"http://example"}},
+	}
+
+	for _, c := range cases {
+		goos = c.goos
+
+		var gotName string
+		var gotArgs []string
+		execCommand = func(name string, args ...string) *exec.Cmd {
+			gotName = name
+			gotArgs = append([]string{}, args...)
+			// Use a harmless command so tests don't actually open a browser.
+			return exec.Command("true")
+		}
+
+		if err := (DefaultOpener{}).Open("http://example"); err != nil {
+			t.Fatalf("goos=%s: err=%v", c.goos, err)
+		}
+		if gotName != c.wantName {
+			t.Fatalf("goos=%s: name got %q want %q", c.goos, gotName, c.wantName)
+		}
+		if len(gotArgs) != len(c.wantArgs) {
+			t.Fatalf("goos=%s: args got %#v want %#v", c.goos, gotArgs, c.wantArgs)
+		}
+		for i := range gotArgs {
+			if gotArgs[i] != c.wantArgs[i] {
+				t.Fatalf("goos=%s: args got %#v want %#v", c.goos, gotArgs, c.wantArgs)
+			}
+		}
 	}
 }

--- a/internal/platform/idempotency/idempotency.go
+++ b/internal/platform/idempotency/idempotency.go
@@ -1,0 +1,8 @@
+package idempotency
+
+import "github.com/google/uuid"
+
+// NewKey returns a new idempotency key suitable for Idempotency-Key headers.
+func NewKey() string {
+	return uuid.NewString()
+}

--- a/internal/platform/idempotency/idempotency_test.go
+++ b/internal/platform/idempotency/idempotency_test.go
@@ -1,0 +1,14 @@
+package idempotency
+
+import "testing"
+
+func TestNewKey_NonEmptyAndDistinct(t *testing.T) {
+	k1 := NewKey()
+	k2 := NewKey()
+	if k1 == "" || k2 == "" {
+		t.Fatalf("expected non-empty keys: %q %q", k1, k2)
+	}
+	if k1 == k2 {
+		t.Fatalf("expected distinct keys, got %q", k1)
+	}
+}

--- a/internal/platform/requestfile/requestfile.go
+++ b/internal/platform/requestfile/requestfile.go
@@ -1,0 +1,118 @@
+package requestfile
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadStrict reads the file at path and decodes it into out.
+//
+// Format detection rules:
+//   - .json => JSON
+//   - .yaml/.yml => YAML
+//   - otherwise: attempt JSON first, then YAML; if both fail, returns an error
+//
+// Decoding is strict: unknown fields are rejected.
+func LoadStrict(path string, out any) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json":
+		return decodeJSONStrict(b, out)
+	case ".yaml", ".yml":
+		return decodeYAMLAsJSONStrict(b, out)
+	default:
+		jsonErr := decodeJSONStrict(b, out)
+		if jsonErr == nil {
+			return nil
+		}
+		yamlErr := decodeYAMLAsJSONStrict(b, out)
+		if yamlErr == nil {
+			return nil
+		}
+		return fmt.Errorf("parse %s: JSON: %v; YAML: %v", path, jsonErr, yamlErr)
+	}
+}
+
+func decodeJSONStrict(b []byte, out any) error {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(out); err != nil {
+		return err
+	}
+	// Ensure decoder is at EOF (covers trailing whitespace, rejects extra tokens).
+	if err := dec.Decode(&struct{}{}); err == nil {
+		return errors.New("unexpected trailing JSON content")
+	} else if !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
+}
+
+func decodeYAMLAsJSONStrict(b []byte, out any) error {
+	var v any
+	if err := yaml.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	norm, err := normalizeYAML(v)
+	if err != nil {
+		return err
+	}
+	j, err := json.Marshal(norm)
+	if err != nil {
+		return err
+	}
+	return decodeJSONStrict(j, out)
+}
+
+func normalizeYAML(v any) (any, error) {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			n, err := normalizeYAML(vv)
+			if err != nil {
+				return nil, err
+			}
+			out[k] = n
+		}
+		return out, nil
+	case map[any]any:
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			ks, ok := k.(string)
+			if !ok {
+				return nil, fmt.Errorf("yaml key must be string, got %T", k)
+			}
+			n, err := normalizeYAML(vv)
+			if err != nil {
+				return nil, err
+			}
+			out[ks] = n
+		}
+		return out, nil
+	case []any:
+		out := make([]any, 0, len(x))
+		for _, vv := range x {
+			n, err := normalizeYAML(vv)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, n)
+		}
+		return out, nil
+	default:
+		return v, nil
+	}
+}

--- a/internal/platform/requestfile/requestfile_test.go
+++ b/internal/platform/requestfile/requestfile_test.go
@@ -1,0 +1,172 @@
+package requestfile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+)
+
+func writeTemp(t *testing.T, ext string, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "req-*"+ext)
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return f.Name()
+}
+
+func TestLoadStrict_JSON_ByExtension(t *testing.T) {
+	p := writeTemp(t, ".json", `{"name":"Trip 1"}`)
+	var req gen.CreateTripDraftRequest
+	if err := LoadStrict(p, &req); err != nil {
+		t.Fatalf("LoadStrict: %v", err)
+	}
+	if req.Name != "Trip 1" {
+		t.Fatalf("name: %q", req.Name)
+	}
+}
+
+func TestLoadStrict_YAML_ByExtension_MultilinePreserved(t *testing.T) {
+	p := writeTemp(t, ".yaml", ""+
+		"description: |\n"+
+		"  line1\n"+
+		"  line2\n")
+
+	var req gen.UpdateTripRequest
+	if err := LoadStrict(p, &req); err != nil {
+		t.Fatalf("LoadStrict: %v", err)
+	}
+	if req.Description == nil {
+		t.Fatalf("expected description set")
+	}
+	if *req.Description != "line1\nline2\n" {
+		t.Fatalf("description: %#v", *req.Description)
+	}
+}
+
+func TestLoadStrict_UnknownExtension_FallbackJSONThenYAML(t *testing.T) {
+	p := writeTemp(t, ".txt", `name: Trip 2`)
+	var req gen.CreateTripDraftRequest
+	if err := LoadStrict(p, &req); err != nil {
+		t.Fatalf("LoadStrict: %v", err)
+	}
+	if req.Name != "Trip 2" {
+		t.Fatalf("name: %q", req.Name)
+	}
+}
+
+func TestLoadStrict_StrictUnknownFields(t *testing.T) {
+	p := writeTemp(t, ".json", `{"name":"Trip 1","extra":1}`)
+	var req gen.CreateTripDraftRequest
+	if err := LoadStrict(p, &req); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestLoadStrict_JSON_ExtensionDoesNotFallbackToYAML(t *testing.T) {
+	// YAML content but .json extension must be treated as JSON and fail.
+	p := writeTemp(t, ".json", "name: Trip 3")
+	var req gen.CreateTripDraftRequest
+	if err := LoadStrict(p, &req); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestNormalizeYAML_RejectsNonStringKeys(t *testing.T) {
+	_, err := normalizeYAML(map[any]any{1: "x"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestNormalizeYAML_MapStringAny_Recurses(t *testing.T) {
+	v, err := normalizeYAML(map[string]any{
+		"a": map[string]any{"b": "c"},
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	m := v.(map[string]any)
+	a := m["a"].(map[string]any)
+	if a["b"] != "c" {
+		t.Fatalf("got: %#v", v)
+	}
+}
+
+func TestNormalizeYAML_MapAnyAny_StringKeys_Succeeds(t *testing.T) {
+	v, err := normalizeYAML(map[any]any{"a": map[any]any{"b": "c"}})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	m := v.(map[string]any)
+	a := m["a"].(map[string]any)
+	if a["b"] != "c" {
+		t.Fatalf("got: %#v", v)
+	}
+}
+
+func TestNormalizeYAML_Slice_Recurses(t *testing.T) {
+	v, err := normalizeYAML([]any{map[any]any{"k": "v"}})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	s := v.([]any)
+	m := s[0].(map[string]any)
+	if m["k"] != "v" {
+		t.Fatalf("got: %#v", v)
+	}
+}
+
+func TestLoadStrict_PathIsInErrorMessageOnFallbackFailure(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "bad.req")
+	if err := os.WriteFile(p, []byte("{"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var req gen.CreateTripDraftRequest
+	if err := LoadStrict(p, &req); err == nil {
+		t.Fatalf("expected error")
+	} else if !strings.Contains(err.Error(), p) {
+		t.Fatalf("expected path in error, got: %v", err)
+	}
+}
+
+func TestLoadStrict_YML_ByExtension(t *testing.T) {
+	p := writeTemp(t, ".yml", "name: Trip\n")
+	var req gen.CreateTripDraftRequest
+	if err := LoadStrict(p, &req); err != nil {
+		t.Fatalf("LoadStrict: %v", err)
+	}
+	if req.Name != "Trip" {
+		t.Fatalf("name: %q", req.Name)
+	}
+}
+
+func TestLoadStrict_UnknownExtension_FallbackBothFail_IncludesBothErrors(t *testing.T) {
+	p := writeTemp(t, ".req", "{")
+	var req gen.CreateTripDraftRequest
+	err := LoadStrict(p, &req)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "JSON:") || !strings.Contains(err.Error(), "YAML:") {
+		t.Fatalf("expected both JSON and YAML errors, got: %v", err)
+	}
+}
+
+func TestLoadStrict_JSON_TrailingContentRejected(t *testing.T) {
+	p := writeTemp(t, ".json", `{"name":"Trip"} {"name":"Trip2"}`)
+	var req gen.CreateTripDraftRequest
+	if err := LoadStrict(p, &req); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/ports/out/plannerapi/plannerapi.go
+++ b/internal/ports/out/plannerapi/plannerapi.go
@@ -15,8 +15,10 @@ import (
 type Client interface {
 	// Trips
 	CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error)
+	UpdateTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.UpdateTripJSONRequestBody) (*gen.UpdateTripClientResponse, error)
 	CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error)
 
 	// Members
 	ListMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.ListMembersParams) (*gen.ListMembersClientResponse, error)
+	UpdateMyMemberProfile(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.UpdateMyMemberProfileJSONRequestBody) (*gen.UpdateMyMemberProfileClientResponse, error)
 }


### PR DESCRIPTION
Adds strict JSON/YAML file-based request input (format detection per spec) for:\n- ebo trip create\n- ebo trip update\n- ebo member update\n\nIncludes tests ensuring parse failure exits 2 and makes no API call; CI coverage gate remains >=85%.\n\nCloses #19