### PR TITLE
feat: add trip list/drafts/get commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Notes:
 - Added `--from-file <path>` JSON/YAML request mode for `ebo trip create`, `ebo trip update`, and `ebo member update`.
 - Added `--edit` editor-based request mode for `ebo trip update` and `ebo member update`.
 - Added `--prompt` interactive guided-entry mode for `ebo trip create`, `ebo trip update`, and `ebo member update`.
+- Added trip read commands: `ebo trip list`, `ebo trip drafts`, and `ebo trip get <tripId>`.
 - Added HTTP runtime helpers for per-request timeouts, verbose request logging, and token redaction.
 - Added an architecture dependency guard test to enforce hex-layer import rules in CI.
 - Added a `plannerapi` outbound port and HTTP adapter wrapping the generated OpenAPI client (auth + idempotency headers + normalized errors).

--- a/internal/adapters/in/cli/fake_plannerapi_extra_test.go
+++ b/internal/adapters/in/cli/fake_plannerapi_extra_test.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"context"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+// Satisfy newly-added plannerapi.Client methods for existing tests that use fakePlannerAPI.
+func (f *fakePlannerAPI) ListVisibleTripsForMember(ctx context.Context, baseURL string, bearerToken string) (*gen.ListVisibleTripsForMemberClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
+}
+
+func (f *fakePlannerAPI) ListMyDraftTrips(ctx context.Context, baseURL string, bearerToken string) (*gen.ListMyDraftTripsClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
+}
+
+func (f *fakePlannerAPI) GetTripDetails(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripDetailsClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
+}

--- a/internal/adapters/in/cli/trip_read_cmd_test.go
+++ b/internal/adapters/in/cli/trip_read_cmd_test.go
@@ -1,0 +1,306 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/config"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	outplannerapi "github.com/BennettSmith/ebo-planner-cli/internal/ports/out/plannerapi"
+)
+
+type fakeTripReadAPI struct {
+	listCalls   int
+	draftsCalls int
+	getCalls    int
+
+	listTrips   []gen.TripSummary
+	draftsTrips []gen.TripSummary
+	getTrip     *gen.TripResponse
+}
+
+var _ outplannerapi.Client = (*fakeTripReadAPI)(nil)
+
+func (f *fakeTripReadAPI) ListVisibleTripsForMember(ctx context.Context, baseURL string, bearerToken string) (*gen.ListVisibleTripsForMemberClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	f.listCalls++
+	return &gen.ListVisibleTripsForMemberClientResponse{
+		JSON200: &struct {
+			Trips []gen.TripSummary `json:"trips"`
+		}{Trips: f.listTrips},
+	}, nil
+}
+
+func (f *fakeTripReadAPI) ListMyDraftTrips(ctx context.Context, baseURL string, bearerToken string) (*gen.ListMyDraftTripsClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	f.draftsCalls++
+	return &gen.ListMyDraftTripsClientResponse{
+		JSON200: &struct {
+			Trips []gen.TripSummary `json:"trips"`
+		}{Trips: f.draftsTrips},
+	}, nil
+}
+
+func (f *fakeTripReadAPI) GetTripDetails(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripDetailsClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	f.getCalls++
+	return &gen.GetTripDetailsClientResponse{JSON200: f.getTrip}, nil
+}
+
+// Unused for these tests, but required by the interface.
+func (f *fakeTripReadAPI) CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = idempotencyKey
+	_ = req
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripReadAPI) UpdateTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.UpdateTripJSONRequestBody) (*gen.UpdateTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = idempotencyKey
+	_ = req
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripReadAPI) CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = idempotencyKey
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripReadAPI) ListMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.ListMembersParams) (*gen.ListMembersClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = params
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripReadAPI) UpdateMyMemberProfile(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.UpdateMyMemberProfileJSONRequestBody) (*gen.UpdateMyMemberProfileClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = idempotencyKey
+	_ = req
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func TestTripList_TableOutput(t *testing.T) {
+	name := "Trip"
+	api := &fakeTripReadAPI{
+		listTrips: []gen.TripSummary{{TripId: "t1", Status: "PUBLISHED", Name: &name}},
+	}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.listCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.listCalls)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("TRIP_ID\tSTATUS\tNAME\n")) {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("t1\tPUBLISHED\tTrip\n")) {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+}
+
+func TestTripList_JSONOutput(t *testing.T) {
+	name := "Trip"
+	api := &fakeTripReadAPI{
+		listTrips: []gen.TripSummary{{TripId: "t1", Status: "PUBLISHED", Name: &name}},
+	}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "trip", "list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	if env["data"] == nil {
+		t.Fatalf("expected data")
+	}
+}
+
+func TestTripDrafts_TableOutput(t *testing.T) {
+	name := "Draft"
+	api := &fakeTripReadAPI{
+		draftsTrips: []gen.TripSummary{{TripId: "t1", Status: "DRAFT", Name: &name}},
+	}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "drafts"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.draftsCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.draftsCalls)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("t1\tDRAFT\tDraft\n")) {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+}
+
+func TestTripDrafts_JSONOutput(t *testing.T) {
+	name := "Draft"
+	api := &fakeTripReadAPI{
+		draftsTrips: []gen.TripSummary{{TripId: "t1", Status: "DRAFT", Name: &name}},
+	}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "trip", "drafts"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	if env["data"] == nil {
+		t.Fatalf("expected data")
+	}
+}
+
+func TestTripGet_TableOutput(t *testing.T) {
+	name := "Trip"
+	api := &fakeTripReadAPI{
+		getTrip: &gen.TripResponse{Trip: gen.TripDetails{TripId: "t1", Status: "PUBLISHED", Name: &name}},
+	}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "get", "t1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.getCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.getCalls)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("TripId: t1")) {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+}
+
+func TestTripGet_JSONOutput(t *testing.T) {
+	name := "Trip"
+	api := &fakeTripReadAPI{
+		getTrip: &gen.TripResponse{Trip: gen.TripDetails{TripId: "t1", Status: "PUBLISHED", Name: &name}},
+	}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "trip", "get", "t1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	if env["data"] == nil {
+		t.Fatalf("expected data")
+	}
+}
+
+func TestTripRead_MissingToken_IsAuth(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithCurrentProfile(doc, "default")
+	doc, _ = config.WithProfileAPIURL(doc, "default", "http://api")
+	store := &memStore{path: "/x", doc: doc}
+
+	api := &fakeTripReadAPI{}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "list"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Auth {
+		t.Fatalf("expected exit 3, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.listCalls != 0 {
+		t.Fatalf("expected no API calls, got %d", api.listCalls)
+	}
+}
+
+func TestTripRead_MissingAPIURL_IsUsage(t *testing.T) {
+	doc := config.NewEmptyDocument()
+	doc, _ = config.WithCurrentProfile(doc, "default")
+	// Provide token but no apiUrl.
+	doc, _ = config.SetString(doc, "profiles.default.auth.accessToken", "tok")
+	store := &memStore{path: "/x", doc: doc}
+
+	api := &fakeTripReadAPI{}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "list"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.listCalls != 0 {
+		t.Fatalf("expected no API calls, got %d", api.listCalls)
+	}
+}
+
+func TestTripList_NilPlannerAPI_IsUnexpected(t *testing.T) {
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: nil, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "list"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Unexpected {
+		t.Fatalf("expected exit 1, got %d (%v)", exitcode.Code(err), err)
+	}
+}

--- a/internal/adapters/out/plannerapi/client.go
+++ b/internal/adapters/out/plannerapi/client.go
@@ -35,6 +35,51 @@ func (a Adapter) newClient(baseURL string, bearerToken string) (*gen.ClientWithR
 	return gen.NewClientWithResponses(baseURL, opts...)
 }
 
+func (a Adapter) ListVisibleTripsForMember(ctx context.Context, baseURL string, bearerToken string) (*gen.ListVisibleTripsForMemberClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	resp, err := client.ListVisibleTripsForMemberWithResponse(ctx)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON500)
+	}
+	return resp, nil
+}
+
+func (a Adapter) ListMyDraftTrips(ctx context.Context, baseURL string, bearerToken string) (*gen.ListMyDraftTripsClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	resp, err := client.ListMyDraftTripsWithResponse(ctx)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON500)
+	}
+	return resp, nil
+}
+
+func (a Adapter) GetTripDetails(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripDetailsClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	resp, err := client.GetTripDetailsWithResponse(ctx, tripID)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON404, resp.JSON500)
+	}
+	return resp, nil
+}
+
 func (a Adapter) CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error) {
 	client, err := a.newClient(baseURL, bearerToken)
 	if err != nil {

--- a/internal/platform/specpin/specpin_test.go
+++ b/internal/platform/specpin/specpin_test.go
@@ -56,6 +56,13 @@ func TestResolveSpecDir_EnvRelative(t *testing.T) {
 	}
 }
 
+func TestVerifyRefExists_NilRunner_UsesExecRunnerAndErrors(t *testing.T) {
+	// This hits the nil-runner fallback branch; it should error because tempdir is not a git repo.
+	if err := VerifyRefExists(nil, t.TempDir(), "nope"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
 func TestVerifyRefExists_OK(t *testing.T) {
 	r := fakeRunner{out: map[string][]byte{
 		"git -C /spec rev-parse --verify v1": []byte("v1\n"),

--- a/internal/ports/out/plannerapi/plannerapi.go
+++ b/internal/ports/out/plannerapi/plannerapi.go
@@ -14,6 +14,9 @@ import (
 // we can introduce domain-level DTOs.
 type Client interface {
 	// Trips
+	ListVisibleTripsForMember(ctx context.Context, baseURL string, bearerToken string) (*gen.ListVisibleTripsForMemberClientResponse, error)
+	ListMyDraftTrips(ctx context.Context, baseURL string, bearerToken string) (*gen.ListMyDraftTripsClientResponse, error)
+	GetTripDetails(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripDetailsClientResponse, error)
 	CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error)
 	UpdateTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.UpdateTripJSONRequestBody) (*gen.UpdateTripClientResponse, error)
 	CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error)


### PR DESCRIPTION
Implements Trips read-only commands backed by the generated API client:\n\n- `ebo trip list` (GET /trips)\n- `ebo trip drafts` (GET /trips/drafts)\n- `ebo trip get <tripId>` (GET /trips/{tripId})\n\nTest plan:\n- Command tests cover flag parsing + output shape in table and json modes\n- Adapter tests verify endpoints and error mapping (401/404/5xx)\n\nCI:\n- `make ci` passes (>=85% internal coverage)\n\nCloses #22