### PR TITLE
feat: add trip visibility/publish/cancel commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Notes:
 - Added `--prompt` interactive guided-entry mode for `ebo trip create`, `ebo trip update`, and `ebo member update`.
 - Added trip read commands: `ebo trip list`, `ebo trip drafts`, and `ebo trip get <tripId>`.
 - Added `ebo trip update` patch flags for common fields (including meeting location and artifacts), plus validation/mutual-exclusion rules for clear/replace semantics.
+- Added trip lifecycle commands: `ebo trip visibility`, `ebo trip publish` (with `--print-announcement`), and `ebo trip cancel` (with `--force`).
 - Added HTTP runtime helpers for per-request timeouts, verbose request logging, and token redaction.
 - Added an architecture dependency guard test to enforce hex-layer import rules in CI.
 - Added a `plannerapi` outbound port and HTTP adapter wrapping the generated OpenAPI client (auth + idempotency headers + normalized errors).

--- a/internal/adapters/in/cli/fake_plannerapi_extra_test.go
+++ b/internal/adapters/in/cli/fake_plannerapi_extra_test.go
@@ -29,3 +29,21 @@ func (f *fakePlannerAPI) GetTripDetails(ctx context.Context, baseURL string, bea
 	_ = tripID
 	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
 }
+
+func (f *fakePlannerAPI) SetTripDraftVisibility(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetTripDraftVisibilityJSONRequestBody) (*gen.SetTripDraftVisibilityClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = idempotencyKey
+	_ = req
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
+}
+
+func (f *fakePlannerAPI) PublishTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.PublishTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
+}

--- a/internal/adapters/in/cli/trip_read_cmd_test.go
+++ b/internal/adapters/in/cli/trip_read_cmd_test.go
@@ -57,6 +57,24 @@ func (f *fakeTripReadAPI) GetTripDetails(ctx context.Context, baseURL string, be
 	return &gen.GetTripDetailsClientResponse{JSON200: f.getTrip}, nil
 }
 
+func (f *fakeTripReadAPI) SetTripDraftVisibility(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetTripDraftVisibilityJSONRequestBody) (*gen.SetTripDraftVisibilityClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = idempotencyKey
+	_ = req
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripReadAPI) PublishTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.PublishTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
 // Unused for these tests, but required by the interface.
 func (f *fakeTripReadAPI) CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error) {
 	_ = ctx

--- a/internal/adapters/in/cli/trip_visibility_publish_cancel_test.go
+++ b/internal/adapters/in/cli/trip_visibility_publish_cancel_test.go
@@ -1,0 +1,244 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	outplannerapi "github.com/BennettSmith/ebo-planner-cli/internal/ports/out/plannerapi"
+)
+
+type fakeTripMutationsAPI struct {
+	visCalls     int
+	publishCalls int
+	cancelCalls  int
+
+	lastVisIdem string
+	lastVisReq  gen.SetDraftVisibilityRequest
+
+	lastCancelIdem *string
+
+	publishResp *gen.PublishTripResponse
+}
+
+var _ outplannerapi.Client = (*fakeTripMutationsAPI)(nil)
+
+func (f *fakeTripMutationsAPI) ListVisibleTripsForMember(ctx context.Context, baseURL string, bearerToken string) (*gen.ListVisibleTripsForMemberClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripMutationsAPI) ListMyDraftTrips(ctx context.Context, baseURL string, bearerToken string) (*gen.ListMyDraftTripsClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripMutationsAPI) GetTripDetails(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripDetailsClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripMutationsAPI) CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripMutationsAPI) UpdateTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.UpdateTripJSONRequestBody) (*gen.UpdateTripClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripMutationsAPI) ListMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.ListMembersParams) (*gen.ListMembersClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripMutationsAPI) UpdateMyMemberProfile(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.UpdateMyMemberProfileJSONRequestBody) (*gen.UpdateMyMemberProfileClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripMutationsAPI) SetTripDraftVisibility(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetTripDraftVisibilityJSONRequestBody) (*gen.SetTripDraftVisibilityClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	f.visCalls++
+	f.lastVisIdem = idempotencyKey
+	f.lastVisReq = req
+	return &gen.SetTripDraftVisibilityClientResponse{JSON200: &gen.TripResponse{}}, nil
+}
+
+func (f *fakeTripMutationsAPI) PublishTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.PublishTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	f.publishCalls++
+	resp := f.publishResp
+	if resp == nil {
+		resp = &gen.PublishTripResponse{AnnouncementCopy: "ANNOUNCE\n"}
+	}
+	return &gen.PublishTripClientResponse{JSON200: resp}, nil
+}
+
+func (f *fakeTripMutationsAPI) CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	f.cancelCalls++
+	f.lastCancelIdem = idempotencyKey
+	return &gen.CancelTripClientResponse{JSON200: &gen.TripResponse{}}, nil
+}
+
+func TestTripPublish_PrintAnnouncement_StdoutOnly(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeTripMutationsAPI{publishResp: &gen.PublishTripResponse{AnnouncementCopy: "HELLO\n"}}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "publish", "t1", "--print-announcement"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if stdout.String() != "HELLO\n" {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr should be empty, got %q", stderr.String())
+	}
+}
+
+func TestTripCancel_RequiresForce(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeTripMutationsAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "cancel", "t1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.cancelCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.cancelCalls)
+	}
+}
+
+func TestTripCancel_IdempotencyOptional_NoAutoGenerate(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeTripMutationsAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "cancel", "t1", "--force"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.cancelCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.cancelCalls)
+	}
+	if api.lastCancelIdem != nil {
+		t.Fatalf("expected nil idempotency, got %v", *api.lastCancelIdem)
+	}
+}
+
+func TestTripVisibility_JSON_IncludesMetaIdempotencyKey(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeTripMutationsAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "trip", "visibility", "t1", "--public"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.visCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.visCalls)
+	}
+	if api.lastVisIdem == "" {
+		t.Fatalf("expected generated idempotency key")
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	meta, _ := env["meta"].(map[string]any)
+	if meta == nil || meta["idempotencyKey"] == "" {
+		t.Fatalf("expected meta.idempotencyKey, got %#v", meta)
+	}
+}
+
+func TestTripVisibility_PublicPrivateMutualExclusion(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeTripMutationsAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "visibility", "t1", "--public", "--private"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.visCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.visCalls)
+	}
+}
+
+func TestTripPublish_JSONOutput_Envelope(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeTripMutationsAPI{publishResp: &gen.PublishTripResponse{AnnouncementCopy: "HELLO\n"}}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "trip", "publish", "t1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.publishCalls != 1 {
+		t.Fatalf("expected 1 api call, got %d", api.publishCalls)
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	if env["data"] == nil {
+		t.Fatalf("expected data")
+	}
+}
+
+func TestTripCancel_WithIdempotency_JSONMetaAndPointer(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeTripMutationsAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "trip", "cancel", "t1", "--force", "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.cancelCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.cancelCalls)
+	}
+	if api.lastCancelIdem == nil || *api.lastCancelIdem != "k1" {
+		if api.lastCancelIdem == nil {
+			t.Fatalf("expected idempotency pointer")
+		}
+		t.Fatalf("idempotency: %q", *api.lastCancelIdem)
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	meta, _ := env["meta"].(map[string]any)
+	if meta == nil || meta["idempotencyKey"] != "k1" {
+		t.Fatalf("meta: %#v", meta)
+	}
+}

--- a/internal/adapters/out/plannerapi/client.go
+++ b/internal/adapters/out/plannerapi/client.go
@@ -112,6 +112,37 @@ func (a Adapter) UpdateTrip(ctx context.Context, baseURL string, bearerToken str
 	return resp, nil
 }
 
+func (a Adapter) SetTripDraftVisibility(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetTripDraftVisibilityJSONRequestBody) (*gen.SetTripDraftVisibilityClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	params := &gen.SetTripDraftVisibilityParams{IdempotencyKey: idempotencyKey}
+	resp, err := client.SetTripDraftVisibilityWithResponse(ctx, tripID, params, req)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON404, resp.JSON409, resp.JSON422, resp.JSON500)
+	}
+	return resp, nil
+}
+
+func (a Adapter) PublishTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.PublishTripClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	resp, err := client.PublishTripWithResponse(ctx, tripID)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON404, resp.JSON409, resp.JSON422, resp.JSON500)
+	}
+	return resp, nil
+}
+
 func (a Adapter) CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error) {
 	client, err := a.newClient(baseURL, bearerToken)
 	if err != nil {

--- a/internal/platform/oidcdevice/coverage_test.go
+++ b/internal/platform/oidcdevice/coverage_test.go
@@ -1,0 +1,15 @@
+package oidcdevice
+
+import "testing"
+
+func TestIsPendingAndIsSlowDown(t *testing.T) {
+	if !(TokenError{Error: "authorization_pending"}).IsPending() {
+		t.Fatalf("expected pending")
+	}
+	if (TokenError{Error: "authorization_pending"}).IsSlowDown() {
+		t.Fatalf("expected not slow_down")
+	}
+	if !(TokenError{Error: "slow_down"}).IsSlowDown() {
+		t.Fatalf("expected slow_down")
+	}
+}

--- a/internal/platform/prompt/prompt_test.go
+++ b/internal/platform/prompt/prompt_test.go
@@ -135,6 +135,19 @@ func TestReadLineCtx_EOFWithoutNewline_ReturnsPartial(t *testing.T) {
 	}
 }
 
+func TestPromptOptionalString_EOFIsOK(t *testing.T) {
+	in := strings.NewReader("x")
+	out := &bytes.Buffer{}
+	p := New(in, out, nil)
+	s, err := p.PromptOptionalString(context.Background(), "Label")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s != "x" {
+		t.Fatalf("got %q", s)
+	}
+}
+
 func TestPromptYesNo_DefaultYes(t *testing.T) {
 	in := strings.NewReader("\n")
 	out := &bytes.Buffer{}

--- a/internal/ports/out/plannerapi/plannerapi.go
+++ b/internal/ports/out/plannerapi/plannerapi.go
@@ -19,6 +19,8 @@ type Client interface {
 	GetTripDetails(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripDetailsClientResponse, error)
 	CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error)
 	UpdateTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.UpdateTripJSONRequestBody) (*gen.UpdateTripClientResponse, error)
+	SetTripDraftVisibility(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetTripDraftVisibilityJSONRequestBody) (*gen.SetTripDraftVisibilityClientResponse, error)
+	PublishTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.PublishTripClientResponse, error)
 	CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error)
 
 	// Members


### PR DESCRIPTION
Implements trip lifecycle commands per Issue #24:\n\n- `ebo trip visibility <tripId> --public|--private` (required idempotency; auto-generated if omitted)\n- `ebo trip publish <tripId>` (intentionally no `--idempotency-key`)\n  - `--print-announcement`: stdout contains ONLY `announcementCopy` (plain text)\n- `ebo trip cancel <tripId>`\n  - requires `--force`\n  - optional `--idempotency-key` (MUST NOT auto-generate)\n\nTest plan:\n- CLI tests cover publish `--print-announcement` stdout-only behavior and cancel `--force` gating\n- Adapter tests cover endpoint wiring + error mapping\n\nCI:\n- `make ci` passes (>=85% internal coverage)\n\nCloses #24