### PR TITLE
feat: add trip organizer add/remove commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Notes:
 - Added trip read commands: `ebo trip list`, `ebo trip drafts`, and `ebo trip get <tripId>`.
 - Added `ebo trip update` patch flags for common fields (including meeting location and artifacts), plus validation/mutual-exclusion rules for clear/replace semantics.
 - Added trip lifecycle commands: `ebo trip visibility`, `ebo trip publish` (with `--print-announcement`), and `ebo trip cancel` (with `--force`).
+- Added trip organizer commands: `ebo trip organizer add` and `ebo trip organizer remove` (with `--force`).
 - Added HTTP runtime helpers for per-request timeouts, verbose request logging, and token redaction.
 - Added an architecture dependency guard test to enforce hex-layer import rules in CI.
 - Added a `plannerapi` outbound port and HTTP adapter wrapping the generated OpenAPI client (auth + idempotency headers + normalized errors).

--- a/internal/adapters/in/cli/fake_plannerapi_extra_test.go
+++ b/internal/adapters/in/cli/fake_plannerapi_extra_test.go
@@ -47,3 +47,23 @@ func (f *fakePlannerAPI) PublishTrip(ctx context.Context, baseURL string, bearer
 	_ = tripID
 	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
 }
+
+func (f *fakePlannerAPI) AddTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.AddTripOrganizerJSONRequestBody) (*gen.AddTripOrganizerClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = idempotencyKey
+	_ = req
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
+}
+
+func (f *fakePlannerAPI) RemoveTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, memberID gen.MemberId, idempotencyKey string) (*gen.RemoveTripOrganizerClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = memberID
+	_ = idempotencyKey
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
+}

--- a/internal/adapters/in/cli/trip_organizer_test.go
+++ b/internal/adapters/in/cli/trip_organizer_test.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	outplannerapi "github.com/BennettSmith/ebo-planner-cli/internal/ports/out/plannerapi"
+)
+
+type fakeTripOrganizerAPI struct {
+	addCalls    int
+	removeCalls int
+
+	lastAddIdem    string
+	lastRemoveIdem string
+
+	lastAddTripID    gen.TripId
+	lastRemoveTripID gen.TripId
+	lastAddReq       gen.AddTripOrganizerJSONRequestBody
+	lastRemoveMember gen.MemberId
+}
+
+var _ outplannerapi.Client = (*fakeTripOrganizerAPI)(nil)
+
+func (f *fakeTripOrganizerAPI) ListVisibleTripsForMember(ctx context.Context, baseURL string, bearerToken string) (*gen.ListVisibleTripsForMemberClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripOrganizerAPI) ListMyDraftTrips(ctx context.Context, baseURL string, bearerToken string) (*gen.ListMyDraftTripsClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripOrganizerAPI) GetTripDetails(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripDetailsClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripOrganizerAPI) CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripOrganizerAPI) UpdateTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.UpdateTripJSONRequestBody) (*gen.UpdateTripClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripOrganizerAPI) SetTripDraftVisibility(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetTripDraftVisibilityJSONRequestBody) (*gen.SetTripDraftVisibilityClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripOrganizerAPI) PublishTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.PublishTripClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripOrganizerAPI) CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripOrganizerAPI) ListMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.ListMembersParams) (*gen.ListMembersClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeTripOrganizerAPI) UpdateMyMemberProfile(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.UpdateMyMemberProfileJSONRequestBody) (*gen.UpdateMyMemberProfileClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripOrganizerAPI) AddTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.AddTripOrganizerJSONRequestBody) (*gen.AddTripOrganizerClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	f.addCalls++
+	f.lastAddTripID = tripID
+	f.lastAddIdem = idempotencyKey
+	f.lastAddReq = req
+	return &gen.AddTripOrganizerClientResponse{JSON200: &gen.TripResponse{}}, nil
+}
+
+func (f *fakeTripOrganizerAPI) RemoveTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, memberID gen.MemberId, idempotencyKey string) (*gen.RemoveTripOrganizerClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	f.removeCalls++
+	f.lastRemoveTripID = tripID
+	f.lastRemoveMember = memberID
+	f.lastRemoveIdem = idempotencyKey
+	return &gen.RemoveTripOrganizerClientResponse{JSON200: &gen.TripResponse{}}, nil
+}
+
+func TestTripOrganizerAdd_AutoGeneratesIdempotency_JSONMetaAndCall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeTripOrganizerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "trip", "organizer", "add", "t1", "--member", "m1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.addCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.addCalls)
+	}
+	if api.lastAddTripID != "t1" || api.lastAddReq.MemberId != "m1" {
+		t.Fatalf("call args: trip=%q member=%q", api.lastAddTripID, api.lastAddReq.MemberId)
+	}
+	if api.lastAddIdem == "" {
+		t.Fatalf("expected generated idempotency key")
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	meta, _ := env["meta"].(map[string]any)
+	if meta == nil || meta["idempotencyKey"] == "" {
+		t.Fatalf("meta: %#v", meta)
+	}
+}
+
+func TestTripOrganizerAdd_MissingMember_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeTripOrganizerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "organizer", "add", "t1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.addCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.addCalls)
+	}
+}
+
+func TestTripOrganizerRemove_RequiresForce(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeTripOrganizerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "organizer", "remove", "t1", "--member", "m1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.removeCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.removeCalls)
+	}
+}
+
+func TestTripOrganizerRemove_AutoGeneratesIdempotency(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeTripOrganizerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "organizer", "remove", "t1", "--member", "m1", "--force"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.removeCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.removeCalls)
+	}
+	if api.lastRemoveIdem == "" {
+		t.Fatalf("expected generated idempotency key")
+	}
+	if api.lastRemoveTripID != "t1" || api.lastRemoveMember != "m1" {
+		t.Fatalf("call args: trip=%q member=%q", api.lastRemoveTripID, api.lastRemoveMember)
+	}
+}

--- a/internal/adapters/in/cli/trip_read_cmd_test.go
+++ b/internal/adapters/in/cli/trip_read_cmd_test.go
@@ -75,6 +75,26 @@ func (f *fakeTripReadAPI) PublishTrip(ctx context.Context, baseURL string, beare
 	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
 }
 
+func (f *fakeTripReadAPI) AddTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.AddTripOrganizerJSONRequestBody) (*gen.AddTripOrganizerClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = idempotencyKey
+	_ = req
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripReadAPI) RemoveTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, memberID gen.MemberId, idempotencyKey string) (*gen.RemoveTripOrganizerClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = memberID
+	_ = idempotencyKey
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
 // Unused for these tests, but required by the interface.
 func (f *fakeTripReadAPI) CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error) {
 	_ = ctx

--- a/internal/adapters/in/cli/trip_visibility_publish_cancel_test.go
+++ b/internal/adapters/in/cli/trip_visibility_publish_cancel_test.go
@@ -82,6 +82,26 @@ func (f *fakeTripMutationsAPI) CancelTrip(ctx context.Context, baseURL string, b
 	return &gen.CancelTripClientResponse{JSON200: &gen.TripResponse{}}, nil
 }
 
+func (f *fakeTripMutationsAPI) AddTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.AddTripOrganizerJSONRequestBody) (*gen.AddTripOrganizerClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = idempotencyKey
+	_ = req
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripMutationsAPI) RemoveTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, memberID gen.MemberId, idempotencyKey string) (*gen.RemoveTripOrganizerClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = memberID
+	_ = idempotencyKey
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
 func TestTripPublish_PrintAnnouncement_StdoutOnly(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}

--- a/internal/adapters/out/plannerapi/client.go
+++ b/internal/adapters/out/plannerapi/client.go
@@ -143,6 +143,38 @@ func (a Adapter) PublishTrip(ctx context.Context, baseURL string, bearerToken st
 	return resp, nil
 }
 
+func (a Adapter) AddTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.AddTripOrganizerJSONRequestBody) (*gen.AddTripOrganizerClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	params := &gen.AddTripOrganizerParams{IdempotencyKey: idempotencyKey}
+	resp, err := client.AddTripOrganizerWithResponse(ctx, tripID, params, req)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON404, resp.JSON409, resp.JSON422, resp.JSON500)
+	}
+	return resp, nil
+}
+
+func (a Adapter) RemoveTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, memberID gen.MemberId, idempotencyKey string) (*gen.RemoveTripOrganizerClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	params := &gen.RemoveTripOrganizerParams{IdempotencyKey: idempotencyKey}
+	resp, err := client.RemoveTripOrganizerWithResponse(ctx, tripID, memberID, params)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON404, resp.JSON409, resp.JSON422, resp.JSON500)
+	}
+	return resp, nil
+}
+
 func (a Adapter) CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error) {
 	client, err := a.newClient(baseURL, bearerToken)
 	if err != nil {

--- a/internal/platform/prompt/prompt_test.go
+++ b/internal/platform/prompt/prompt_test.go
@@ -148,6 +148,19 @@ func TestPromptOptionalString_EOFIsOK(t *testing.T) {
 	}
 }
 
+func TestPromptOptionalString_EOFEmptyReturnsEmpty(t *testing.T) {
+	in := strings.NewReader("")
+	out := &bytes.Buffer{}
+	p := New(in, out, nil)
+	s, err := p.PromptOptionalString(context.Background(), "Label")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s != "" {
+		t.Fatalf("got %q", s)
+	}
+}
+
 func TestPromptYesNo_DefaultYes(t *testing.T) {
 	in := strings.NewReader("\n")
 	out := &bytes.Buffer{}

--- a/internal/ports/out/plannerapi/plannerapi.go
+++ b/internal/ports/out/plannerapi/plannerapi.go
@@ -21,6 +21,8 @@ type Client interface {
 	UpdateTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.UpdateTripJSONRequestBody) (*gen.UpdateTripClientResponse, error)
 	SetTripDraftVisibility(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetTripDraftVisibilityJSONRequestBody) (*gen.SetTripDraftVisibilityClientResponse, error)
 	PublishTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.PublishTripClientResponse, error)
+	AddTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.AddTripOrganizerJSONRequestBody) (*gen.AddTripOrganizerClientResponse, error)
+	RemoveTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, memberID gen.MemberId, idempotencyKey string) (*gen.RemoveTripOrganizerClientResponse, error)
 	CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error)
 
 	// Members


### PR DESCRIPTION
Implements trip organizer management per Issue #25:\n\n- `ebo trip organizer add <tripId> --member <memberId>`\n  - Idempotency-Key required; auto-generated if omitted\n- `ebo trip organizer remove <tripId> --member <memberId>`\n  - requires `--force`\n  - Idempotency-Key required; auto-generated if omitted\n\nTest plan:\n- CLI tests cover `--force` gating, idempotency key generation behavior, and correct request payloads\n- Adapter tests validate endpoint paths + idempotency header + error mapping\n\nCI:\n- `make ci` passes (>=85% internal coverage)\n\nCloses #25