### PR TITLE
feat: add trip rsvp commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Notes:
 - Added `ebo trip update` patch flags for common fields (including meeting location and artifacts), plus validation/mutual-exclusion rules for clear/replace semantics.
 - Added trip lifecycle commands: `ebo trip visibility`, `ebo trip publish` (with `--print-announcement`), and `ebo trip cancel` (with `--force`).
 - Added trip organizer commands: `ebo trip organizer add` and `ebo trip organizer remove` (with `--force`).
+- Added trip RSVP commands: `ebo trip rsvp set|get|summary` (with `--yes|--no|--unset` for `set`).
 - Added HTTP runtime helpers for per-request timeouts, verbose request logging, and token redaction.
 - Added an architecture dependency guard test to enforce hex-layer import rules in CI.
 - Added a `plannerapi` outbound port and HTTP adapter wrapping the generated OpenAPI client (auth + idempotency headers + normalized errors).

--- a/cmd/ebo/main_test.go
+++ b/cmd/ebo/main_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/adapters/out/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+func TestBuildErrorEnvelope_IncludesRequestIDWhenPresent(t *testing.T) {
+	peek := cliopts.GlobalOptions{APIURL: "http://api", Profile: "default"}
+	err := exitcode.New(exitcode.KindAuth, "unauthorized", &plannerapi.APIError{RequestID: "req-1"})
+	env := buildErrorEnvelope(peek, err)
+	if env.Meta.RequestID != "req-1" {
+		t.Fatalf("requestId: got %q", env.Meta.RequestID)
+	}
+}

--- a/internal/adapters/in/cli/fake_plannerapi_extra_test.go
+++ b/internal/adapters/in/cli/fake_plannerapi_extra_test.go
@@ -67,3 +67,29 @@ func (f *fakePlannerAPI) RemoveTripOrganizer(ctx context.Context, baseURL string
 	_ = idempotencyKey
 	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
 }
+
+func (f *fakePlannerAPI) SetMyRSVP(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetMyRSVPJSONRequestBody) (*gen.SetMyRSVPClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = idempotencyKey
+	_ = req
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
+}
+
+func (f *fakePlannerAPI) GetMyRSVPForTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetMyRSVPForTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
+}
+
+func (f *fakePlannerAPI) GetTripRSVPSummary(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripRSVPSummaryClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
+}

--- a/internal/adapters/in/cli/trip_organizer_test.go
+++ b/internal/adapters/in/cli/trip_organizer_test.go
@@ -79,6 +79,32 @@ func (f *fakeTripOrganizerAPI) RemoveTripOrganizer(ctx context.Context, baseURL 
 	return &gen.RemoveTripOrganizerClientResponse{JSON200: &gen.TripResponse{}}, nil
 }
 
+func (f *fakeTripOrganizerAPI) SetMyRSVP(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetMyRSVPJSONRequestBody) (*gen.SetMyRSVPClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = idempotencyKey
+	_ = req
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripOrganizerAPI) GetMyRSVPForTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetMyRSVPForTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripOrganizerAPI) GetTripRSVPSummary(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripRSVPSummaryClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
 func TestTripOrganizerAdd_AutoGeneratesIdempotency_JSONMetaAndCall(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}

--- a/internal/adapters/in/cli/trip_read_cmd_test.go
+++ b/internal/adapters/in/cli/trip_read_cmd_test.go
@@ -95,6 +95,32 @@ func (f *fakeTripReadAPI) RemoveTripOrganizer(ctx context.Context, baseURL strin
 	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
 }
 
+func (f *fakeTripReadAPI) SetMyRSVP(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetMyRSVPJSONRequestBody) (*gen.SetMyRSVPClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = idempotencyKey
+	_ = req
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripReadAPI) GetMyRSVPForTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetMyRSVPForTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripReadAPI) GetTripRSVPSummary(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripRSVPSummaryClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
 // Unused for these tests, but required by the interface.
 func (f *fakeTripReadAPI) CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error) {
 	_ = ctx

--- a/internal/adapters/in/cli/trip_rsvp_test.go
+++ b/internal/adapters/in/cli/trip_rsvp_test.go
@@ -1,0 +1,325 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	outplannerapi "github.com/BennettSmith/ebo-planner-cli/internal/ports/out/plannerapi"
+)
+
+type fakeRSVPAPI struct {
+	setCalls     int
+	getCalls     int
+	summaryCalls int
+
+	lastSetIdem string
+	lastSetReq  gen.SetMyRSVPRequest
+
+	getResp     *gen.GetMyRSVPForTripClientResponse
+	summaryResp *gen.GetTripRSVPSummaryClientResponse
+}
+
+var _ outplannerapi.Client = (*fakeRSVPAPI)(nil)
+
+func (f *fakeRSVPAPI) ListVisibleTripsForMember(ctx context.Context, baseURL string, bearerToken string) (*gen.ListVisibleTripsForMemberClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeRSVPAPI) ListMyDraftTrips(ctx context.Context, baseURL string, bearerToken string) (*gen.ListMyDraftTripsClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeRSVPAPI) GetTripDetails(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripDetailsClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeRSVPAPI) CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeRSVPAPI) UpdateTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.UpdateTripJSONRequestBody) (*gen.UpdateTripClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeRSVPAPI) SetTripDraftVisibility(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetTripDraftVisibilityJSONRequestBody) (*gen.SetTripDraftVisibilityClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeRSVPAPI) PublishTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.PublishTripClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeRSVPAPI) AddTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.AddTripOrganizerJSONRequestBody) (*gen.AddTripOrganizerClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeRSVPAPI) RemoveTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, memberID gen.MemberId, idempotencyKey string) (*gen.RemoveTripOrganizerClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeRSVPAPI) CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeRSVPAPI) ListMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.ListMembersParams) (*gen.ListMembersClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeRSVPAPI) UpdateMyMemberProfile(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.UpdateMyMemberProfileJSONRequestBody) (*gen.UpdateMyMemberProfileClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeRSVPAPI) SetMyRSVP(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetMyRSVPJSONRequestBody) (*gen.SetMyRSVPClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	f.setCalls++
+	f.lastSetIdem = idempotencyKey
+	f.lastSetReq = req
+	return &gen.SetMyRSVPClientResponse{JSON200: &gen.SetMyRSVPResponse{MyRsvp: gen.MyRSVP{Response: req.Response}}}, nil
+}
+
+func (f *fakeRSVPAPI) GetMyRSVPForTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetMyRSVPForTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	f.getCalls++
+	if f.getResp != nil {
+		return f.getResp, nil
+	}
+	return &gen.GetMyRSVPForTripClientResponse{JSON200: &struct {
+		MyRsvp gen.MyRSVP `json:"myRsvp"`
+	}{MyRsvp: gen.MyRSVP{Response: gen.YES}}}, nil
+}
+
+func (f *fakeRSVPAPI) GetTripRSVPSummary(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripRSVPSummaryClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	f.summaryCalls++
+	if f.summaryResp != nil {
+		return f.summaryResp, nil
+	}
+	return &gen.GetTripRSVPSummaryClientResponse{JSON200: &struct {
+		RsvpSummary gen.TripRSVPSummary `json:"rsvpSummary"`
+	}{RsvpSummary: gen.TripRSVPSummary{AttendingRigs: 1}}}, nil
+}
+
+func TestTripRSVPSet_MutuallyExclusiveFlags(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeRSVPAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "rsvp", "set", "t1", "--yes", "--no"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.setCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.setCalls)
+	}
+}
+
+func TestTripRSVPSet_MissingChoice_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeRSVPAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "rsvp", "set", "t1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.setCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.setCalls)
+	}
+}
+
+func TestTripRSVPSet_AutoGeneratesIdempotency_JSONMeta(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeRSVPAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "trip", "rsvp", "set", "t1", "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.setCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.setCalls)
+	}
+	if api.lastSetIdem == "" {
+		t.Fatalf("expected generated idempotency key")
+	}
+	if api.lastSetReq.Response != gen.YES {
+		t.Fatalf("response: %q", api.lastSetReq.Response)
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	meta, _ := env["meta"].(map[string]any)
+	if meta == nil || meta["idempotencyKey"] == "" {
+		t.Fatalf("meta: %#v", meta)
+	}
+}
+
+func TestTripRSVPGet_JSONEnvelope(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeRSVPAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "trip", "rsvp", "get", "t1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.getCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.getCalls)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	if env["data"] == nil {
+		t.Fatalf("expected data")
+	}
+}
+
+func TestTripRSVPSet_Unset_SendsUNSET(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeRSVPAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "rsvp", "set", "t1", "--unset", "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.setCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.setCalls)
+	}
+	if api.lastSetIdem != "k1" {
+		t.Fatalf("idempotency: %q", api.lastSetIdem)
+	}
+	if api.lastSetReq.Response != gen.UNSET {
+		t.Fatalf("response: %q", api.lastSetReq.Response)
+	}
+}
+
+func TestTripRSVPSummary_JSONEnvelope(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeRSVPAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "trip", "rsvp", "summary", "t1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.summaryCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.summaryCalls)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	if env["data"] == nil {
+		t.Fatalf("expected data")
+	}
+}
+
+func TestTripRSVPSet_DefaultOutput_PrintsIdempotency(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeRSVPAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "rsvp", "set", "t1", "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Idempotency-Key: ") {
+		t.Fatalf("stderr: %q", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "OK") {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+}
+
+func TestTripRSVPGet_TableOutput(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeRSVPAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "rsvp", "get", "t1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Response:") {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+}
+
+func TestTripRSVPSummary_TableOutput(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeRSVPAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "rsvp", "summary", "t1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "AttendingRigs:") {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+}
+
+func TestTripRSVPGet_TableOutput_JSON200Nil_PrintsOK(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeRSVPAPI{getResp: &gen.GetMyRSVPForTripClientResponse{}}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "rsvp", "get", "t1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if stdout.String() != "OK\n" {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+}
+
+func TestTripRSVPSummary_TableOutput_JSON200Nil_PrintsOK(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeRSVPAPI{summaryResp: &gen.GetTripRSVPSummaryClientResponse{}}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"trip", "rsvp", "summary", "t1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if stdout.String() != "OK\n" {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+}

--- a/internal/adapters/in/cli/trip_visibility_publish_cancel_test.go
+++ b/internal/adapters/in/cli/trip_visibility_publish_cancel_test.go
@@ -102,6 +102,32 @@ func (f *fakeTripMutationsAPI) RemoveTripOrganizer(ctx context.Context, baseURL 
 	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
 }
 
+func (f *fakeTripMutationsAPI) SetMyRSVP(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetMyRSVPJSONRequestBody) (*gen.SetMyRSVPClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	_ = idempotencyKey
+	_ = req
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripMutationsAPI) GetMyRSVPForTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetMyRSVPForTripClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripMutationsAPI) GetTripRSVPSummary(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripRSVPSummaryClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = tripID
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
 func TestTripPublish_PrintAnnouncement_StdoutOnly(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}

--- a/internal/adapters/out/plannerapi/client.go
+++ b/internal/adapters/out/plannerapi/client.go
@@ -175,6 +175,52 @@ func (a Adapter) RemoveTripOrganizer(ctx context.Context, baseURL string, bearer
 	return resp, nil
 }
 
+func (a Adapter) SetMyRSVP(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetMyRSVPJSONRequestBody) (*gen.SetMyRSVPClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	params := &gen.SetMyRSVPParams{IdempotencyKey: idempotencyKey}
+	resp, err := client.SetMyRSVPWithResponse(ctx, tripID, params, req)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON404, resp.JSON409, resp.JSON422, resp.JSON500)
+	}
+	return resp, nil
+}
+
+func (a Adapter) GetMyRSVPForTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetMyRSVPForTripClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	resp, err := client.GetMyRSVPForTripWithResponse(ctx, tripID)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON404, resp.JSON409, resp.JSON500)
+	}
+	return resp, nil
+}
+
+func (a Adapter) GetTripRSVPSummary(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripRSVPSummaryClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	resp, err := client.GetTripRSVPSummaryWithResponse(ctx, tripID)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON404, resp.JSON409, resp.JSON500)
+	}
+	return resp, nil
+}
+
 func (a Adapter) CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error) {
 	client, err := a.newClient(baseURL, bearerToken)
 	if err != nil {

--- a/internal/ports/out/plannerapi/plannerapi.go
+++ b/internal/ports/out/plannerapi/plannerapi.go
@@ -24,6 +24,9 @@ type Client interface {
 	AddTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.AddTripOrganizerJSONRequestBody) (*gen.AddTripOrganizerClientResponse, error)
 	RemoveTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, memberID gen.MemberId, idempotencyKey string) (*gen.RemoveTripOrganizerClientResponse, error)
 	CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error)
+	SetMyRSVP(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetMyRSVPJSONRequestBody) (*gen.SetMyRSVPClientResponse, error)
+	GetMyRSVPForTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetMyRSVPForTripClientResponse, error)
+	GetTripRSVPSummary(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripRSVPSummaryClientResponse, error)
 
 	// Members
 	ListMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.ListMembersParams) (*gen.ListMembersClientResponse, error)


### PR DESCRIPTION
Implements trip RSVP commands per Issue #26:\n\n- `ebo trip rsvp set <tripId> --yes|--no|--unset`\n  - Idempotency-Key required; auto-generated if omitted\n- `ebo trip rsvp get <tripId>`\n- `ebo trip rsvp summary <tripId>`\n\nAlso ensures JSON error output includes `meta.requestId` when available.\n\nTest plan:\n- CLI tests cover mutually exclusive flags, idempotency behavior, and JSON/table output branches\n- Adapter tests cover endpoints, idempotency header, and error mapping\n- `make ci` passes (>=85% internal coverage)\n\nCloses #26