### PR TITLE
feat: add member read commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Notes:
 - Added trip lifecycle commands: `ebo trip visibility`, `ebo trip publish` (with `--print-announcement`), and `ebo trip cancel` (with `--force`).
 - Added trip organizer commands: `ebo trip organizer add` and `ebo trip organizer remove` (with `--force`).
 - Added trip RSVP commands: `ebo trip rsvp set|get|summary` (with `--yes|--no|--unset` for `set`).
+- Added member read commands: `ebo member list|search|me`.
 - Added HTTP runtime helpers for per-request timeouts, verbose request logging, and token redaction.
 - Added an architecture dependency guard test to enforce hex-layer import rules in CI.
 - Added a `plannerapi` outbound port and HTTP adapter wrapping the generated OpenAPI client (auth + idempotency headers + normalized errors).

--- a/internal/adapters/in/cli/fake_plannerapi_extra_test.go
+++ b/internal/adapters/in/cli/fake_plannerapi_extra_test.go
@@ -93,3 +93,18 @@ func (f *fakePlannerAPI) GetTripRSVPSummary(ctx context.Context, baseURL string,
 	_ = tripID
 	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
 }
+
+func (f *fakePlannerAPI) SearchMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.SearchMembersParams) (*gen.SearchMembersClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = params
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
+}
+
+func (f *fakePlannerAPI) GetMyMemberProfile(ctx context.Context, baseURL string, bearerToken string) (*gen.GetMyMemberProfileClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in this test fake", nil)
+}

--- a/internal/adapters/in/cli/member_cmd.go
+++ b/internal/adapters/in/cli/member_cmd.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
+	plannerapiout "github.com/BennettSmith/ebo-planner-cli/internal/adapters/out/plannerapi"
 	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
 	"github.com/BennettSmith/ebo-planner-cli/internal/platform/cliopts"
 	"github.com/BennettSmith/ebo-planner-cli/internal/platform/editmode"
@@ -22,8 +24,167 @@ func addMemberCommands(root *cobra.Command, deps RootDeps) {
 		Use:   "member",
 		Short: "Member operations",
 	}
+	memberCmd.AddCommand(newMemberListCmd(deps))
+	memberCmd.AddCommand(newMemberSearchCmd(deps))
+	memberCmd.AddCommand(newMemberMeCmd(deps))
 	memberCmd.AddCommand(newMemberUpdateCmd(deps))
 	root.AddCommand(memberCmd)
+}
+
+func newMemberListCmd(deps RootDeps) *cobra.Command {
+	var includeInactive bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List members",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = args
+			ctx := cmd.Context()
+			if deps.PlannerAPI == nil {
+				return exitcode.New(exitcode.KindUnexpected, "planner api", fmt.Errorf("nil planner api client"))
+			}
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			apiCtx, err := resolveAPIContext(ctx, deps, resolved)
+			if err != nil {
+				return err
+			}
+
+			var params *gen.ListMembersParams
+			if includeInactive {
+				v := gen.IncludeInactive(true)
+				params = &gen.ListMembersParams{IncludeInactive: &v}
+			}
+
+			resp, err := deps.PlannerAPI.ListMembers(ctx, apiCtx.APIURL, apiCtx.BearerToken, params)
+			if err != nil {
+				return err
+			}
+
+			entries := []gen.MemberDirectoryEntry{}
+			if resp.JSON200 != nil {
+				entries = resp.JSON200.Members
+			}
+
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: resp.JSON200,
+					Meta: envelope.Meta{APIURL: apiCtx.APIURL, Profile: apiCtx.Profile},
+				})
+			}
+
+			_, _ = io.WriteString(deps.Stdout, "MEMBER_ID\tDISPLAY_NAME\n")
+			for _, m := range entries {
+				_, _ = fmt.Fprintf(deps.Stdout, "%s\t%s\n", m.MemberId, m.DisplayName)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&includeInactive, "include-inactive", false, "Include inactive members")
+	return cmd
+}
+
+func newMemberSearchCmd(deps RootDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search members by display name",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if deps.PlannerAPI == nil {
+				return exitcode.New(exitcode.KindUnexpected, "planner api", fmt.Errorf("nil planner api client"))
+			}
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			apiCtx, err := resolveAPIContext(ctx, deps, resolved)
+			if err != nil {
+				return err
+			}
+
+			q := strings.TrimSpace(args[0])
+			if len(q) < 3 {
+				return exitcode.New(exitcode.KindUsage, "query must be at least 3 characters", nil)
+			}
+			params := &gen.SearchMembersParams{Q: gen.SearchQuery(q)}
+			resp, err := deps.PlannerAPI.SearchMembers(ctx, apiCtx.APIURL, apiCtx.BearerToken, params)
+			if err != nil {
+				return err
+			}
+
+			entries := []gen.MemberDirectoryEntry{}
+			if resp.JSON200 != nil {
+				entries = resp.JSON200.Members
+			}
+
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: resp.JSON200,
+					Meta: envelope.Meta{APIURL: apiCtx.APIURL, Profile: apiCtx.Profile},
+				})
+			}
+
+			_, _ = io.WriteString(deps.Stdout, "MEMBER_ID\tDISPLAY_NAME\n")
+			for _, m := range entries {
+				_, _ = fmt.Fprintf(deps.Stdout, "%s\t%s\n", m.MemberId, m.DisplayName)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newMemberMeCmd(deps RootDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "me",
+		Short: "Get my member profile",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = args
+			ctx := cmd.Context()
+			if deps.PlannerAPI == nil {
+				return exitcode.New(exitcode.KindUnexpected, "planner api", fmt.Errorf("nil planner api client"))
+			}
+			resolved, err := resolvedFromRoot(cmd, deps)
+			if err != nil {
+				return err
+			}
+			apiCtx, err := resolveAPIContext(ctx, deps, resolved)
+			if err != nil {
+				return err
+			}
+
+			resp, err := deps.PlannerAPI.GetMyMemberProfile(ctx, apiCtx.APIURL, apiCtx.BearerToken)
+			if err != nil {
+				var ae *plannerapiout.APIError
+				if errors.As(err, &ae) && ae != nil && ae.ErrorCode == "MEMBER_NOT_PROVISIONED" {
+					return exitcode.New(exitcode.KindNotFound, "member not provisioned; run `ebo member create ...`", err)
+				}
+				return err
+			}
+
+			if resolved.Options.Output == cliopts.OutputJSON {
+				return envelope.WriteJSON(deps.Stdout, envelope.Envelope{
+					Data: resp.JSON200,
+					Meta: envelope.Meta{APIURL: apiCtx.APIURL, Profile: apiCtx.Profile},
+				})
+			}
+
+			if resp.JSON200 == nil {
+				_, _ = io.WriteString(deps.Stdout, "OK\n")
+				return nil
+			}
+			m := resp.JSON200.Member
+			groupAlias := ""
+			if m.GroupAliasEmail != nil {
+				groupAlias = string(*m.GroupAliasEmail)
+			}
+			_, _ = fmt.Fprintf(deps.Stdout, "MemberId: %s\nDisplayName: %s\nEmail: %s\nGroupAliasEmail: %s\n", m.MemberId, m.DisplayName, string(m.Email), groupAlias)
+			return nil
+		},
+	}
+	return cmd
 }
 
 func newMemberUpdateCmd(deps RootDeps) *cobra.Command {

--- a/internal/adapters/in/cli/member_read_cmd_test.go
+++ b/internal/adapters/in/cli/member_read_cmd_test.go
@@ -1,0 +1,287 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	plannerapiout "github.com/BennettSmith/ebo-planner-cli/internal/adapters/out/plannerapi"
+	gen "github.com/BennettSmith/ebo-planner-cli/internal/gen/plannerapi"
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+	outplannerapi "github.com/BennettSmith/ebo-planner-cli/internal/ports/out/plannerapi"
+)
+
+type fakeMemberReadAPI struct {
+	listCalls   int
+	searchCalls int
+	meCalls     int
+
+	lastListParams   *gen.ListMembersParams
+	lastSearchParams *gen.SearchMembersParams
+
+	meResp *gen.GetMyMemberProfileClientResponse
+	meErr  error
+}
+
+var _ outplannerapi.Client = (*fakeMemberReadAPI)(nil)
+
+// Trips (unused)
+func (f *fakeMemberReadAPI) ListVisibleTripsForMember(ctx context.Context, baseURL string, bearerToken string) (*gen.ListVisibleTripsForMemberClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeMemberReadAPI) ListMyDraftTrips(ctx context.Context, baseURL string, bearerToken string) (*gen.ListMyDraftTripsClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeMemberReadAPI) GetTripDetails(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripDetailsClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeMemberReadAPI) CreateTripDraft(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.CreateTripDraftJSONRequestBody) (*gen.CreateTripDraftClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeMemberReadAPI) UpdateTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.UpdateTripJSONRequestBody) (*gen.UpdateTripClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeMemberReadAPI) SetTripDraftVisibility(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetTripDraftVisibilityJSONRequestBody) (*gen.SetTripDraftVisibilityClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeMemberReadAPI) PublishTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.PublishTripClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeMemberReadAPI) AddTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.AddTripOrganizerJSONRequestBody) (*gen.AddTripOrganizerClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeMemberReadAPI) RemoveTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, memberID gen.MemberId, idempotencyKey string) (*gen.RemoveTripOrganizerClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeMemberReadAPI) CancelTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey *string) (*gen.CancelTripClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeMemberReadAPI) SetMyRSVP(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetMyRSVPJSONRequestBody) (*gen.SetMyRSVPClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeMemberReadAPI) GetMyRSVPForTrip(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetMyRSVPForTripClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+func (f *fakeMemberReadAPI) GetTripRSVPSummary(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId) (*gen.GetTripRSVPSummaryClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+// Members
+func (f *fakeMemberReadAPI) ListMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.ListMembersParams) (*gen.ListMembersClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	f.listCalls++
+	f.lastListParams = params
+	return &gen.ListMembersClientResponse{JSON200: &struct {
+		Members []gen.MemberDirectoryEntry `json:"members"`
+	}{Members: []gen.MemberDirectoryEntry{{MemberId: "m1", DisplayName: "Alice"}}}}, nil
+}
+
+func (f *fakeMemberReadAPI) SearchMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.SearchMembersParams) (*gen.SearchMembersClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	f.searchCalls++
+	f.lastSearchParams = params
+	return &gen.SearchMembersClientResponse{JSON200: &struct {
+		Members []gen.MemberDirectoryEntry `json:"members"`
+	}{Members: []gen.MemberDirectoryEntry{{MemberId: "m2", DisplayName: "Bob"}}}}, nil
+}
+
+func (f *fakeMemberReadAPI) GetMyMemberProfile(ctx context.Context, baseURL string, bearerToken string) (*gen.GetMyMemberProfileClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	f.meCalls++
+	if f.meErr != nil {
+		return nil, f.meErr
+	}
+	if f.meResp != nil {
+		return f.meResp, nil
+	}
+	return &gen.GetMyMemberProfileClientResponse{JSON200: &struct {
+		Member gen.MemberProfile `json:"member"`
+	}{Member: gen.MemberProfile{MemberId: "m1", DisplayName: "Me", Email: "me@example.com"}}}, nil
+}
+
+func (f *fakeMemberReadAPI) UpdateMyMemberProfile(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.UpdateMyMemberProfileJSONRequestBody) (*gen.UpdateMyMemberProfileClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func TestMemberSearch_MinLen3_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeMemberReadAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "search", "ab"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.searchCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.searchCalls)
+	}
+}
+
+func TestMemberMe_MemberNotProvisioned_IsNotFound_WithGuidance(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeMemberReadAPI{
+		meErr: exitcode.New(exitcode.KindConflict, "conflict", &plannerapiout.APIError{StatusCode: 409, ErrorCode: "MEMBER_NOT_PROVISIONED", Message: "missing"}),
+	}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "me"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.NotFound {
+		t.Fatalf("expected exit 4, got %d (%v)", exitcode.Code(err), err)
+	}
+	if !strings.Contains(err.Error(), "ebo member create") {
+		t.Fatalf("expected guidance, got %q", err.Error())
+	}
+}
+
+func TestMemberList_JSONEnvelope(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeMemberReadAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "member", "list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.listCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.listCalls)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	if env["data"] == nil {
+		t.Fatalf("expected data")
+	}
+}
+
+func TestMemberList_IncludeInactive_SetsParam(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeMemberReadAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "list", "--include-inactive"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.lastListParams == nil || api.lastListParams.IncludeInactive == nil || bool(*api.lastListParams.IncludeInactive) != true {
+		t.Fatalf("params: %#v", api.lastListParams)
+	}
+}
+
+func TestMemberSearch_JSONEnvelope(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeMemberReadAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "member", "search", "bob"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.searchCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", api.searchCalls)
+	}
+	if api.lastSearchParams == nil || api.lastSearchParams.Q != "bob" {
+		t.Fatalf("params: %#v", api.lastSearchParams)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	if env["data"] == nil {
+		t.Fatalf("expected data")
+	}
+}
+
+func TestMemberSearch_TableOutput(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeMemberReadAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "search", "bob"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "MEMBER_ID") || !strings.Contains(stdout.String(), "m2") {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+}
+
+func TestMemberMe_JSONEnvelope(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeMemberReadAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "member", "me"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	if env["data"] == nil {
+		t.Fatalf("expected data")
+	}
+}
+
+func TestMemberMe_TableOutput(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeMemberReadAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "me"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "MemberId:") {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+}
+
+func TestMemberMe_TableOutput_JSON200Nil_PrintsOK(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakeMemberReadAPI{meResp: &gen.GetMyMemberProfileClientResponse{}}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "me"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if stdout.String() != "OK\n" {
+		t.Fatalf("stdout: %q", stdout.String())
+	}
+}

--- a/internal/adapters/in/cli/trip_organizer_test.go
+++ b/internal/adapters/in/cli/trip_organizer_test.go
@@ -57,6 +57,14 @@ func (f *fakeTripOrganizerAPI) UpdateMyMemberProfile(ctx context.Context, baseUR
 	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
 }
 
+func (f *fakeTripOrganizerAPI) SearchMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.SearchMembersParams) (*gen.SearchMembersClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripOrganizerAPI) GetMyMemberProfile(ctx context.Context, baseURL string, bearerToken string) (*gen.GetMyMemberProfileClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
 func (f *fakeTripOrganizerAPI) AddTripOrganizer(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.AddTripOrganizerJSONRequestBody) (*gen.AddTripOrganizerClientResponse, error) {
 	_ = ctx
 	_ = baseURL

--- a/internal/adapters/in/cli/trip_read_cmd_test.go
+++ b/internal/adapters/in/cli/trip_read_cmd_test.go
@@ -95,6 +95,21 @@ func (f *fakeTripReadAPI) RemoveTripOrganizer(ctx context.Context, baseURL strin
 	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
 }
 
+func (f *fakeTripReadAPI) SearchMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.SearchMembersParams) (*gen.SearchMembersClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	_ = params
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripReadAPI) GetMyMemberProfile(ctx context.Context, baseURL string, bearerToken string) (*gen.GetMyMemberProfileClientResponse, error) {
+	_ = ctx
+	_ = baseURL
+	_ = bearerToken
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
 func (f *fakeTripReadAPI) SetMyRSVP(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetMyRSVPJSONRequestBody) (*gen.SetMyRSVPClientResponse, error) {
 	_ = ctx
 	_ = baseURL

--- a/internal/adapters/in/cli/trip_rsvp_test.go
+++ b/internal/adapters/in/cli/trip_rsvp_test.go
@@ -63,6 +63,14 @@ func (f *fakeRSVPAPI) UpdateMyMemberProfile(ctx context.Context, baseURL string,
 	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
 }
 
+func (f *fakeRSVPAPI) SearchMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.SearchMembersParams) (*gen.SearchMembersClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeRSVPAPI) GetMyMemberProfile(ctx context.Context, baseURL string, bearerToken string) (*gen.GetMyMemberProfileClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
 func (f *fakeRSVPAPI) SetMyRSVP(ctx context.Context, baseURL string, bearerToken string, tripID gen.TripId, idempotencyKey string, req gen.SetMyRSVPJSONRequestBody) (*gen.SetMyRSVPClientResponse, error) {
 	_ = ctx
 	_ = baseURL

--- a/internal/adapters/in/cli/trip_visibility_publish_cancel_test.go
+++ b/internal/adapters/in/cli/trip_visibility_publish_cancel_test.go
@@ -44,6 +44,14 @@ func (f *fakeTripMutationsAPI) UpdateTrip(ctx context.Context, baseURL string, b
 func (f *fakeTripMutationsAPI) ListMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.ListMembersParams) (*gen.ListMembersClientResponse, error) {
 	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
 }
+
+func (f *fakeTripMutationsAPI) SearchMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.SearchMembersParams) (*gen.SearchMembersClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
+
+func (f *fakeTripMutationsAPI) GetMyMemberProfile(ctx context.Context, baseURL string, bearerToken string) (*gen.GetMyMemberProfileClientResponse, error) {
+	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
+}
 func (f *fakeTripMutationsAPI) UpdateMyMemberProfile(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.UpdateMyMemberProfileJSONRequestBody) (*gen.UpdateMyMemberProfileClientResponse, error) {
 	return nil, exitcode.New(exitcode.KindUnexpected, "not implemented in test", nil)
 }

--- a/internal/adapters/out/plannerapi/client.go
+++ b/internal/adapters/out/plannerapi/client.go
@@ -252,6 +252,36 @@ func (a Adapter) ListMembers(ctx context.Context, baseURL string, bearerToken st
 	return resp, nil
 }
 
+func (a Adapter) SearchMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.SearchMembersParams) (*gen.SearchMembersClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	resp, err := client.SearchMembersWithResponse(ctx, params)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON422, resp.JSON500)
+	}
+	return resp, nil
+}
+
+func (a Adapter) GetMyMemberProfile(ctx context.Context, baseURL string, bearerToken string) (*gen.GetMyMemberProfileClientResponse, error) {
+	client, err := a.newClient(baseURL, bearerToken)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "failed to init client", err)
+	}
+	resp, err := client.GetMyMemberProfileWithResponse(ctx)
+	if err != nil {
+		return nil, exitcode.New(exitcode.KindServer, "request failed", err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apiErrorFromAny(resp.StatusCode(), resp.JSON401, resp.JSON404, resp.JSON500)
+	}
+	return resp, nil
+}
+
 func (a Adapter) UpdateMyMemberProfile(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.UpdateMyMemberProfileJSONRequestBody) (*gen.UpdateMyMemberProfileClientResponse, error) {
 	client, err := a.newClient(baseURL, bearerToken)
 	if err != nil {

--- a/internal/ports/out/plannerapi/plannerapi.go
+++ b/internal/ports/out/plannerapi/plannerapi.go
@@ -30,5 +30,7 @@ type Client interface {
 
 	// Members
 	ListMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.ListMembersParams) (*gen.ListMembersClientResponse, error)
+	SearchMembers(ctx context.Context, baseURL string, bearerToken string, params *gen.SearchMembersParams) (*gen.SearchMembersClientResponse, error)
+	GetMyMemberProfile(ctx context.Context, baseURL string, bearerToken string) (*gen.GetMyMemberProfileClientResponse, error)
 	UpdateMyMemberProfile(ctx context.Context, baseURL string, bearerToken string, idempotencyKey string, req gen.UpdateMyMemberProfileJSONRequestBody) (*gen.UpdateMyMemberProfileClientResponse, error)
 }


### PR DESCRIPTION
Implements member read-only commands per Issue #27:\n\n- `ebo member list [--include-inactive]`\n- `ebo member search <query>` (validates min length 3)\n- `ebo member me`\n  - if API returns `MEMBER_NOT_PROVISIONED`, CLI surfaces as 404/exit 4 and guides user to `ebo member create ...`\n\nTest plan:\n- CLI tests cover search query validation and MEMBER_NOT_PROVISIONED guidance\n- Adapter tests cover endpoints and error mapping\n- `make ci` passes (>=85% internal coverage)\n\nCloses #27