### PR TITLE
feat: member update patch flags + clear semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Notes:
 - Added trip RSVP commands: `ebo trip rsvp set|get|summary` (with `--yes|--no|--unset` for `set`).
 - Added member read commands: `ebo member list|search|me`.
 - Added `ebo member create` for provisioning a member profile (no `--idempotency-key`; natural retry via API).
+- Added patch flags and clear semantics for `ebo member update` (including vehicle clear flags and idempotency key auto-generation).
 - Added HTTP runtime helpers for per-request timeouts, verbose request logging, and token redaction.
 - Added an architecture dependency guard test to enforce hex-layer import rules in CI.
 - Added a `plannerapi` outbound port and HTTP adapter wrapping the generated OpenAPI client (auth + idempotency headers + normalized errors).

--- a/internal/adapters/in/cli/member_cmd.go
+++ b/internal/adapters/in/cli/member_cmd.go
@@ -378,6 +378,31 @@ func newMemberUpdateCmd(deps RootDeps) *cobra.Command {
 		edit           bool
 		promptMode     bool
 		idempotencyKey string
+
+		displayName      string
+		clearDisplayName bool
+		email            string
+		groupAliasEmail  string
+		clearGroupAlias  bool
+
+		vehicleMake             string
+		vehicleModel            string
+		vehicleTireSize         string
+		vehicleLiftLockers      string
+		vehicleFuelRange        string
+		vehicleRecoveryGear     string
+		vehicleHamRadioCallSign string
+		vehicleNotes            string
+
+		clearVehicle             bool
+		clearVehicleMake         bool
+		clearVehicleModel        bool
+		clearVehicleTireSize     bool
+		clearVehicleLiftLockers  bool
+		clearVehicleFuelRange    bool
+		clearVehicleRecoveryGear bool
+		clearVehicleHamRadio     bool
+		clearVehicleNotes        bool
 	)
 
 	cmd := &cobra.Command{
@@ -400,7 +425,35 @@ func newMemberUpdateCmd(deps RootDeps) *cobra.Command {
 				return err
 			}
 
+			flagsMode := false
+			for _, name := range []string{
+				"display-name",
+				"email",
+				"group-alias-email",
+				"vehicle-make",
+				"vehicle-model",
+				"vehicle-tire-size",
+				"vehicle-lift-lockers",
+				"vehicle-fuel-range",
+				"vehicle-recovery-gear",
+				"vehicle-ham-radio-call-sign",
+				"vehicle-notes",
+			} {
+				if cmd.Flags().Changed(name) {
+					flagsMode = true
+				}
+			}
+			if clearDisplayName || clearGroupAlias || clearVehicle ||
+				clearVehicleMake || clearVehicleModel || clearVehicleTireSize ||
+				clearVehicleLiftLockers || clearVehicleFuelRange || clearVehicleRecoveryGear ||
+				clearVehicleHamRadio || clearVehicleNotes {
+				flagsMode = true
+			}
+
 			modeCount := 0
+			if flagsMode {
+				modeCount++
+			}
 			if strings.TrimSpace(fromFile) != "" {
 				modeCount++
 			}
@@ -411,14 +464,182 @@ func newMemberUpdateCmd(deps RootDeps) *cobra.Command {
 				modeCount++
 			}
 			if modeCount == 0 {
-				return exitcode.New(exitcode.KindUsage, "missing input (use --from-file, --edit, or --prompt)", nil)
+				return exitcode.New(exitcode.KindUsage, "missing input (provide patch flags or use --from-file/--edit/--prompt)", nil)
 			}
 			if modeCount > 1 {
-				return exitcode.New(exitcode.KindUsage, "choose exactly one of --from-file, --edit, or --prompt", nil)
+				return exitcode.New(exitcode.KindUsage, "choose exactly one patch mode: flags, --from-file, --edit, or --prompt", nil)
 			}
 
 			var req gen.UpdateMyMemberProfileRequest
 			switch {
+			case flagsMode:
+				rejectMultiline := func(label, v string) error {
+					if strings.ContainsAny(v, "\r\n") {
+						return exitcode.New(exitcode.KindUsage, fmt.Sprintf("%s must not be multi-line; use --from-file/--edit/--prompt instead", label), nil)
+					}
+					return nil
+				}
+
+				if cmd.Flags().Changed("display-name") {
+					if err := rejectMultiline("--display-name", displayName); err != nil {
+						return err
+					}
+					v := strings.TrimSpace(displayName)
+					if v == "" {
+						return exitcode.New(exitcode.KindUsage, "--display-name must be non-empty (use --clear-display-name to clear)", nil)
+					}
+					req.DisplayName = &v
+				}
+				if clearDisplayName {
+					if cmd.Flags().Changed("display-name") {
+						return exitcode.New(exitcode.KindUsage, "cannot use --display-name with --clear-display-name", nil)
+					}
+					empty := ""
+					req.DisplayName = &empty
+				}
+
+				if cmd.Flags().Changed("email") {
+					if err := rejectMultiline("--email", email); err != nil {
+						return err
+					}
+					v := strings.TrimSpace(email)
+					if v == "" {
+						return exitcode.New(exitcode.KindUsage, "--email must be non-empty", nil)
+					}
+					if _, err := mail.ParseAddress(v); err != nil {
+						return exitcode.New(exitcode.KindUsage, "invalid --email", err)
+					}
+					ev := openapi_types.Email(v)
+					req.Email = &ev
+				}
+
+				if cmd.Flags().Changed("group-alias-email") {
+					if err := rejectMultiline("--group-alias-email", groupAliasEmail); err != nil {
+						return err
+					}
+					v := strings.TrimSpace(groupAliasEmail)
+					if v == "" {
+						return exitcode.New(exitcode.KindUsage, "--group-alias-email must be non-empty (use --clear-group-alias-email to clear)", nil)
+					}
+					if _, err := mail.ParseAddress(v); err != nil {
+						return exitcode.New(exitcode.KindUsage, "invalid --group-alias-email", err)
+					}
+					ev := openapi_types.Email(v)
+					req.GroupAliasEmail = &ev
+				}
+				if clearGroupAlias {
+					if cmd.Flags().Changed("group-alias-email") {
+						return exitcode.New(exitcode.KindUsage, "cannot use --group-alias-email with --clear-group-alias-email", nil)
+					}
+					empty := openapi_types.Email("")
+					req.GroupAliasEmail = &empty
+				}
+
+				vehicleAnySetOrClear := false
+				if cmd.Flags().Changed("vehicle-make") || cmd.Flags().Changed("vehicle-model") || cmd.Flags().Changed("vehicle-tire-size") ||
+					cmd.Flags().Changed("vehicle-lift-lockers") || cmd.Flags().Changed("vehicle-fuel-range") || cmd.Flags().Changed("vehicle-recovery-gear") ||
+					cmd.Flags().Changed("vehicle-ham-radio-call-sign") || cmd.Flags().Changed("vehicle-notes") ||
+					clearVehicleMake || clearVehicleModel || clearVehicleTireSize || clearVehicleLiftLockers || clearVehicleFuelRange ||
+					clearVehicleRecoveryGear || clearVehicleHamRadio || clearVehicleNotes || clearVehicle {
+					vehicleAnySetOrClear = true
+				}
+
+				if clearVehicle && (cmd.Flags().Changed("vehicle-make") || cmd.Flags().Changed("vehicle-model") || cmd.Flags().Changed("vehicle-tire-size") ||
+					cmd.Flags().Changed("vehicle-lift-lockers") || cmd.Flags().Changed("vehicle-fuel-range") || cmd.Flags().Changed("vehicle-recovery-gear") ||
+					cmd.Flags().Changed("vehicle-ham-radio-call-sign") || cmd.Flags().Changed("vehicle-notes") ||
+					clearVehicleMake || clearVehicleModel || clearVehicleTireSize || clearVehicleLiftLockers || clearVehicleFuelRange ||
+					clearVehicleRecoveryGear || clearVehicleHamRadio || clearVehicleNotes) {
+					return exitcode.New(exitcode.KindUsage, "--clear-vehicle cannot be combined with other vehicle flags", nil)
+				}
+
+				if vehicleAnySetOrClear {
+					var vp gen.VehicleProfile
+					empty := ""
+					if clearVehicle {
+						vp = gen.VehicleProfile{
+							Make:             &empty,
+							Model:            &empty,
+							TireSize:         &empty,
+							LiftLockers:      &empty,
+							FuelRange:        &empty,
+							RecoveryGear:     &empty,
+							HamRadioCallSign: &empty,
+							Notes:            &empty,
+						}
+						req.VehicleProfile = &vp
+					} else {
+						setField := func(flag string, label string, raw string, dst **string) error {
+							if !cmd.Flags().Changed(flag) {
+								return nil
+							}
+							if err := rejectMultiline(label, raw); err != nil {
+								return err
+							}
+							v := strings.TrimSpace(raw)
+							if v == "" {
+								return exitcode.New(exitcode.KindUsage, fmt.Sprintf("%s must be non-empty (use the corresponding --clear-* flag to clear)", label), nil)
+							}
+							*dst = &v
+							return nil
+						}
+						if err := setField("vehicle-make", "--vehicle-make", vehicleMake, &vp.Make); err != nil {
+							return err
+						}
+						if err := setField("vehicle-model", "--vehicle-model", vehicleModel, &vp.Model); err != nil {
+							return err
+						}
+						if err := setField("vehicle-tire-size", "--vehicle-tire-size", vehicleTireSize, &vp.TireSize); err != nil {
+							return err
+						}
+						if err := setField("vehicle-lift-lockers", "--vehicle-lift-lockers", vehicleLiftLockers, &vp.LiftLockers); err != nil {
+							return err
+						}
+						if err := setField("vehicle-fuel-range", "--vehicle-fuel-range", vehicleFuelRange, &vp.FuelRange); err != nil {
+							return err
+						}
+						if err := setField("vehicle-recovery-gear", "--vehicle-recovery-gear", vehicleRecoveryGear, &vp.RecoveryGear); err != nil {
+							return err
+						}
+						if err := setField("vehicle-ham-radio-call-sign", "--vehicle-ham-radio-call-sign", vehicleHamRadioCallSign, &vp.HamRadioCallSign); err != nil {
+							return err
+						}
+						if err := setField("vehicle-notes", "--vehicle-notes", vehicleNotes, &vp.Notes); err != nil {
+							return err
+						}
+
+						if clearVehicleMake {
+							vp.Make = &empty
+						}
+						if clearVehicleModel {
+							vp.Model = &empty
+						}
+						if clearVehicleTireSize {
+							vp.TireSize = &empty
+						}
+						if clearVehicleLiftLockers {
+							vp.LiftLockers = &empty
+						}
+						if clearVehicleFuelRange {
+							vp.FuelRange = &empty
+						}
+						if clearVehicleRecoveryGear {
+							vp.RecoveryGear = &empty
+						}
+						if clearVehicleHamRadio {
+							vp.HamRadioCallSign = &empty
+						}
+						if clearVehicleNotes {
+							vp.Notes = &empty
+						}
+
+						req.VehicleProfile = &vp
+					}
+				}
+
+				// Must change at least one field.
+				if req.DisplayName == nil && req.Email == nil && req.GroupAliasEmail == nil && req.VehicleProfile == nil {
+					return exitcode.New(exitcode.KindUsage, "no changes specified", nil)
+				}
 			case edit:
 				edited, err := editmode.EditTemp(updateMemberTemplateYAML)
 				if err != nil {
@@ -522,6 +743,31 @@ func newMemberUpdateCmd(deps RootDeps) *cobra.Command {
 	cmd.Flags().BoolVar(&edit, "edit", false, "Edit request body in $EBO_EDITOR/$EDITOR (YAML template)")
 	cmd.Flags().BoolVar(&promptMode, "prompt", false, "Interactive guided entry")
 	cmd.Flags().StringVar(&idempotencyKey, "idempotency-key", "", "Idempotency key (auto-generated if omitted)")
+
+	cmd.Flags().StringVar(&displayName, "display-name", "", "Display name")
+	cmd.Flags().BoolVar(&clearDisplayName, "clear-display-name", false, "Clear display name")
+	cmd.Flags().StringVar(&email, "email", "", "Email")
+	cmd.Flags().StringVar(&groupAliasEmail, "group-alias-email", "", "Group alias email")
+	cmd.Flags().BoolVar(&clearGroupAlias, "clear-group-alias-email", false, "Clear group alias email")
+
+	cmd.Flags().StringVar(&vehicleMake, "vehicle-make", "", "Vehicle make")
+	cmd.Flags().StringVar(&vehicleModel, "vehicle-model", "", "Vehicle model")
+	cmd.Flags().StringVar(&vehicleTireSize, "vehicle-tire-size", "", "Vehicle tire size")
+	cmd.Flags().StringVar(&vehicleLiftLockers, "vehicle-lift-lockers", "", "Vehicle lift/lockers")
+	cmd.Flags().StringVar(&vehicleFuelRange, "vehicle-fuel-range", "", "Vehicle fuel range")
+	cmd.Flags().StringVar(&vehicleRecoveryGear, "vehicle-recovery-gear", "", "Vehicle recovery gear")
+	cmd.Flags().StringVar(&vehicleHamRadioCallSign, "vehicle-ham-radio-call-sign", "", "Vehicle HAM radio call sign")
+	cmd.Flags().StringVar(&vehicleNotes, "vehicle-notes", "", "Vehicle notes (single-line only; use file/edit/prompt for multi-line)")
+
+	cmd.Flags().BoolVar(&clearVehicle, "clear-vehicle", false, "Clear the entire vehicle profile")
+	cmd.Flags().BoolVar(&clearVehicleMake, "clear-vehicle-make", false, "Clear vehicle make")
+	cmd.Flags().BoolVar(&clearVehicleModel, "clear-vehicle-model", false, "Clear vehicle model")
+	cmd.Flags().BoolVar(&clearVehicleTireSize, "clear-vehicle-tire-size", false, "Clear vehicle tire size")
+	cmd.Flags().BoolVar(&clearVehicleLiftLockers, "clear-vehicle-lift-lockers", false, "Clear vehicle lift/lockers")
+	cmd.Flags().BoolVar(&clearVehicleFuelRange, "clear-vehicle-fuel-range", false, "Clear vehicle fuel range")
+	cmd.Flags().BoolVar(&clearVehicleRecoveryGear, "clear-vehicle-recovery-gear", false, "Clear vehicle recovery gear")
+	cmd.Flags().BoolVar(&clearVehicleHamRadio, "clear-vehicle-ham-radio-call-sign", false, "Clear vehicle HAM radio call sign")
+	cmd.Flags().BoolVar(&clearVehicleNotes, "clear-vehicle-notes", false, "Clear vehicle notes")
 
 	return cmd
 }

--- a/internal/adapters/in/cli/member_update_flags_test.go
+++ b/internal/adapters/in/cli/member_update_flags_test.go
@@ -1,0 +1,346 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/BennettSmith/ebo-planner-cli/internal/platform/exitcode"
+)
+
+func TestMemberUpdate_FlagsAndFromFile_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	p := writeTempFile(t, "member.yaml", "displayName: x\n")
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--display-name", "X", "--from-file", p})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.memberCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.memberCalls)
+	}
+}
+
+func TestMemberUpdate_AutoGeneratesIdempotency_JSONMetaAndCall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"--output", "json", "member", "update", "--display-name", "X"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.memberCalls != 1 {
+		t.Fatalf("expected 1 api call, got %d", api.memberCalls)
+	}
+	if api.lastMemberIdem == "" {
+		t.Fatalf("expected idempotency key")
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout not json: %v\n%s", err, stdout.String())
+	}
+	meta, _ := env["meta"].(map[string]any)
+	if meta == nil || meta["idempotencyKey"] == "" {
+		t.Fatalf("meta: %#v", meta)
+	}
+	if meta["idempotencyKey"] != api.lastMemberIdem {
+		t.Fatalf("idempotency mismatch meta=%v call=%q", meta["idempotencyKey"], api.lastMemberIdem)
+	}
+}
+
+func TestMemberUpdate_ClearVehicle_SetsAllFieldsEmpty(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--clear-vehicle", "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.memberCalls != 1 {
+		t.Fatalf("expected 1 api call, got %d", api.memberCalls)
+	}
+	if api.lastMemberReq.VehicleProfile == nil || api.lastMemberReq.VehicleProfile.Make == nil || api.lastMemberReq.VehicleProfile.Notes == nil {
+		t.Fatalf("vehicleProfile: %#v", api.lastMemberReq.VehicleProfile)
+	}
+	if *api.lastMemberReq.VehicleProfile.Make != "" || *api.lastMemberReq.VehicleProfile.Notes != "" {
+		t.Fatalf("expected cleared fields, got make=%q notes=%q", *api.lastMemberReq.VehicleProfile.Make, *api.lastMemberReq.VehicleProfile.Notes)
+	}
+}
+
+func TestMemberUpdate_ClearVehicle_AndVehicleMake_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--clear-vehicle", "--vehicle-make", "Toyota", "--idempotency-key", "k1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.memberCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.memberCalls)
+	}
+}
+
+func TestMemberUpdate_DisplayNameAndClearDisplayName_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--display-name", "X", "--clear-display-name"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.memberCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.memberCalls)
+	}
+}
+
+func TestMemberUpdate_GroupAliasAndClearGroupAlias_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--group-alias-email", "ga@example.com", "--clear-group-alias-email"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.memberCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.memberCalls)
+	}
+}
+
+func TestMemberUpdate_InvalidEmail_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--email", "not-an-email", "--idempotency-key", "k1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.memberCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.memberCalls)
+	}
+}
+
+func TestMemberUpdate_SetEmail_SetsReqField(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--email", "a@example.com", "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.memberCalls != 1 {
+		t.Fatalf("expected 1 api call, got %d", api.memberCalls)
+	}
+	if api.lastMemberReq.Email == nil || string(*api.lastMemberReq.Email) != "a@example.com" {
+		t.Fatalf("email: %#v", api.lastMemberReq.Email)
+	}
+}
+
+func TestMemberUpdate_ClearGroupAlias_SetsEmpty(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--clear-group-alias-email", "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.memberCalls != 1 {
+		t.Fatalf("expected 1 api call, got %d", api.memberCalls)
+	}
+	if api.lastMemberReq.GroupAliasEmail == nil || string(*api.lastMemberReq.GroupAliasEmail) != "" {
+		t.Fatalf("groupAliasEmail: %#v", api.lastMemberReq.GroupAliasEmail)
+	}
+}
+
+func TestMemberUpdate_ClearVehicleMake_SetsEmpty(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--clear-vehicle-make", "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.lastMemberReq.VehicleProfile == nil || api.lastMemberReq.VehicleProfile.Make == nil || *api.lastMemberReq.VehicleProfile.Make != "" {
+		t.Fatalf("vehicleProfile.make: %#v", api.lastMemberReq.VehicleProfile)
+	}
+}
+
+func TestMemberUpdate_EditAndFlags_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--edit", "--display-name", "X"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.memberCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.memberCalls)
+	}
+}
+
+func TestMemberUpdate_PromptAndFlags_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--prompt", "--display-name", "X"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.memberCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.memberCalls)
+	}
+}
+
+func TestMemberUpdate_ClearDisplayName_SetsEmpty(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--clear-display-name", "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.lastMemberReq.DisplayName == nil || *api.lastMemberReq.DisplayName != "" {
+		t.Fatalf("displayName: %#v", api.lastMemberReq.DisplayName)
+	}
+}
+
+func TestMemberUpdate_SetGroupAliasEmail_SetsField(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--group-alias-email", "ga@example.com", "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.lastMemberReq.GroupAliasEmail == nil || string(*api.lastMemberReq.GroupAliasEmail) != "ga@example.com" {
+		t.Fatalf("groupAliasEmail: %#v", api.lastMemberReq.GroupAliasEmail)
+	}
+}
+
+func TestMemberUpdate_SetVehicleMake_SetsField(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--vehicle-make", "Toyota", "--idempotency-key", "k1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if api.lastMemberReq.VehicleProfile == nil || api.lastMemberReq.VehicleProfile.Make == nil || *api.lastMemberReq.VehicleProfile.Make != "Toyota" {
+		t.Fatalf("vehicleProfile: %#v", api.lastMemberReq.VehicleProfile)
+	}
+}
+
+func TestMemberUpdate_VehicleMakeEmpty_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	// Use = to force the flag to be treated as "changed" with an empty value.
+	cmd.SetArgs([]string{"member", "update", "--vehicle-make=", "--idempotency-key", "k1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.memberCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.memberCalls)
+	}
+}
+
+func TestMemberUpdate_MultilineVehicleNotes_IsUsage_NoAPICall(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	store := &memStore{path: "/x", doc: baseDoc(t)}
+	api := &fakePlannerAPI{}
+
+	cmd := NewRootCmd(RootDeps{ConfigStore: store, PlannerAPI: api, Stdout: stdout, Stderr: stderr})
+	cmd.SetArgs([]string{"member", "update", "--vehicle-notes", "a\nb", "--idempotency-key", "k1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if exitcode.Code(err) != exitcode.Usage {
+		t.Fatalf("expected exit 2, got %d (%v)", exitcode.Code(err), err)
+	}
+	if api.memberCalls != 0 {
+		t.Fatalf("expected no api calls, got %d", api.memberCalls)
+	}
+}

--- a/internal/adapters/in/cli/trip_member_fromfile_test.go
+++ b/internal/adapters/in/cli/trip_member_fromfile_test.go
@@ -75,7 +75,9 @@ func (f *fakePlannerAPI) UpdateMyMemberProfile(ctx context.Context, baseURL stri
 	f.memberCalls++
 	f.lastMemberIdem = idempotencyKey
 	f.lastMemberReq = req
-	return &gen.UpdateMyMemberProfileClientResponse{JSON200: &gen.UpdateMyMemberProfileResponse{}}, nil
+	return &gen.UpdateMyMemberProfileClientResponse{JSON200: &gen.UpdateMyMemberProfileResponse{
+		Member: gen.MemberProfile{MemberId: "m1", DisplayName: "n", Email: "a@example.com"},
+	}}, nil
 }
 
 func writeTempFile(t *testing.T, name string, content string) string {


### PR DESCRIPTION
Implements `ebo member update` patch flag mode per Issue #29:\n\n- Adds patch flags for `--display-name`, `--email`, `--group-alias-email`, and vehicle fields\n- Adds explicit clear flags (including `--clear-vehicle` and per-field vehicle clear flags)\n- Enforces patch mode exclusivity: flags vs `--from-file`/`--edit`/`--prompt`\n- Idempotency-Key required; auto-generated if omitted\n- Rejects multi-line values via flags (exit 2; no API request)\n\nTest plan:\n- CLI tests cover mode exclusivity, idempotency auto-gen, and vehicle clear semantics\n- `make ci` passes (>=85% internal coverage)\n\nCloses #29